### PR TITLE
JE-403: Removed deprecations from logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Changed monolog config to ignore deprecations.
+
 ## [1.1.2]
 
 * Changed how project billing is put on record, to allow for finishing a partially

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -9,19 +9,11 @@ when@dev:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
-                channels: ["!event"]
-            # uncomment to get logging in your browser
-            # you may have to allow bigger header sizes in your Web server configuration
-            #firephp:
-            #    type: firephp
-            #    level: info
-            #chromephp:
-            #    type: chromephp
-            #    level: info
+                channels: ["!event", "!doctrine", "!deprecation"]
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine", "!console"]
+                channels: ["!event", "!doctrine", "!console", "!deprecation"]
 
 when@test:
     monolog:
@@ -46,16 +38,17 @@ when@prod:
                 handler: nested
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+                channels: ["!event", "!doctrine", "!deprecation"]
             nested:
                 type: stream
                 path: php://stderr
                 level: debug
                 formatter: monolog.formatter.json
+                channels: ["!event", "!doctrine", "!deprecation"]
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!deprecation"]
             deprecation:
-                type: stream
+                type: "null"
                 channels: [deprecation]
-                path: php://stderr


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/JE-403

#### Description

Changed monolog config to ignore deprecations.

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
