### PR TITLE
#182: Default to work id worker not longer exists in Leantime worklog…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Default to work id worker not longer exists in Leantime worklog sync.
 * Added commands to manage data providers.
 * Changed how errors are handled in Leantime api calls.
 * Modified getSprintReportData to work with Leantime data

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -271,7 +271,7 @@ class LeantimeApiService implements DataProviderServiceInterface
             if (isset($worklog->ticketId)) {
                 $worklogData->projectTrackerId = $worklog->id;
                 $worklogData->comment = $worklog->description ?? '';
-                $worklogData->worker = $workers[$worklog->userId];
+                $worklogData->worker = $workers[$worklog->userId] ?? $worklog->userId;
                 $worklogData->timeSpentSeconds = (int) ($worklog->hours * 60 * 60);
                 $worklogData->started = new \DateTime($worklog->workDate);
                 $worklogData->projectTrackerIsBilled = false;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/182

#### Description

Default to work id worker not longer exists in Leantime worklog sync.

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
