### PR TITLE
Feature/588: project-dataprovider visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added leantime support for projects and project sync.
 * Added week-based planning view, based on issue duedates.
 * Fixed minor leantime integration issues.
+* Added dataprovider as column in project list.
 
 
 * RELEASE NOTES:

--- a/src/Form/InvoiceNewType.php
+++ b/src/Form/InvoiceNewType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form;
 
+use App\Entity\Project;
 use App\Entity\Invoice;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
@@ -25,6 +26,9 @@ class InvoiceNewType extends AbstractType
                         ->orderBy('p.name', 'ASC');
                 },
                 'attr' => ['class' => 'form-element'],
+                'choice_label' => function (Project $pr) {
+                    return $pr->getName() . " (" . $pr->getDataProvider() . ")";
+                }
             ])
         ;
     }

--- a/src/Form/InvoiceNewType.php
+++ b/src/Form/InvoiceNewType.php
@@ -2,8 +2,8 @@
 
 namespace App\Form;
 
-use App\Entity\Project;
 use App\Entity\Invoice;
+use App\Entity\Project;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -27,8 +27,8 @@ class InvoiceNewType extends AbstractType
                 },
                 'attr' => ['class' => 'form-element'],
                 'choice_label' => function (Project $pr) {
-                    return $pr->getName() . " (" . $pr->getDataProvider() . ")";
-                }
+                    return $pr->getName().' ('.$pr->getDataProvider().')';
+                },
             ])
         ;
     }

--- a/templates/project/index.html.twig
+++ b/templates/project/index.html.twig
@@ -25,6 +25,7 @@
         <tr>
             <th class="table-th{% if projects.isSorted('project.id') %} sorted{% endif %}">{{ knp_pagination_sortable(projects, 'project.id'|trans, 'project.id') }}</th>
             <th class="table-th{% if projects.isSorted('project.name') %} sorted{% endif %}">{{ knp_pagination_sortable(projects, 'project.name'|trans, 'project.name') }}</th>
+            <th class="table-th">{{ 'project.data_provider_id'|trans }}</th>
             <th class="table-th{% if projects.isSorted('project.projectTrackerKey') %} sorted{% endif %}">{{ knp_pagination_sortable(projects, 'project.project_tracker_key'|trans, 'project.projectTrackerKey') }}</th>
             <th class="table-th{% if projects.isSorted('project.updatedAt') %} sorted{% endif %}">{{ knp_pagination_sortable(projects, 'project.updated_at'|trans, 'project.updatedAt') }}</th>
             <th class="table-th">{{ 'project.include'|trans }}</th>
@@ -36,6 +37,7 @@
             <tr class="{{ index % 2 == 0 ? 'table-tr' : 'table-tr-alt' }}">
                 <td class="table-td">{{ project.id }}</td>
                 <td class="table-td">{{ project.name }}</td>
+                <td class="table-td">{{ project.dataprovider }}</td>
                 <td class="table-td">{{ project.projectTrackerKey }}</td>
                 <td class="table-td">{{ project.updatedAt ? project.updatedAt|date : '' }}</td>
                 <td class="table-td">

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -442,6 +442,7 @@ project:
   form_key: "Nøgle"
   form_include: "Inkluderet"
   information: "Kun inkluderede projekter bliver vist og synkroniseret i resten af system."
+  data_provider_id: "Data Provider"
 
 exception:
   invoices_record_entry_amount_not_set: "Faktura can ikke bogføres, da den indeholder fakturalinjer hvor antal ikke er sat. Se: %invoiceEntryUrl%."


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showAll?search=true&projectId=37&users=3&sprint=21&tab=ticketdetails#/tickets/showTicket/588

#### Description

It should be visible what dataprovider belongs to a given project. Both in the project list and in the dropdown with projects that is available when creating a new invoice.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
