### PR TITLE
973: Made price on client optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-93](https://github.com/itk-dev/economics/pull/93)
+  Made price on client optional
 * [PR-87](https://github.com/itk-dev/economics/pull/87)
-  Fixed Leantime API reqeust
+  Fixed Leantime API request
 * [PR-91](https://github.com/itk-dev/economics/pull/91)
   Updated standard price on clients
 * [PR-89](https://github.com/itk-dev/economics/pull/89)

--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -43,11 +43,9 @@ class ClientController extends AbstractController
     public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
         $client = new Client();
-        if (isset($this->options['standard_price'])) {
-            $client->setStandardPrice((float) $this->options['standard_price']);
-        }
-
-        $form = $this->createForm(ClientType::class, $client);
+        $form = $this->createForm(ClientType::class, $client, [
+            'standard_price' => $this->options['standard_price'],
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -74,7 +72,9 @@ class ClientController extends AbstractController
     #[Route('/{id}/edit', name: 'app_client_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, Client $client, EntityManagerInterface $entityManager): Response
     {
-        $form = $this->createForm(ClientType::class, $client);
+        $form = $this->createForm(ClientType::class, $client, [
+            'standard_price' => $this->options['standard_price'],
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Form/ClientType.php
+++ b/src/Form/ClientType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatableMessage;
 
 class ClientType extends AbstractType
 {
@@ -47,8 +48,8 @@ class ClientType extends AbstractType
                 'label_attr' => ['class' => 'label'],
                 'attr' => ['class' => 'form-element', 'min' => 0],
                 'help_attr' => ['class' => 'form-help'],
-                'help' => 'create_client_form.client_standardPrice.help',
-                'required' => true,
+                'help' => new TranslatableMessage('create_client_form.client_standardPrice.help', ['%standard_price%' => $options['standard_price']]),
+                'required' => false,
                 'row_attr' => ['class' => 'form-row'],
                 'html5' => true,
             ])
@@ -131,8 +132,11 @@ class ClientType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults([
-            'data_class' => Client::class,
-        ]);
+        $resolver
+            ->setDefaults([
+                'data_class' => Client::class,
+            ])
+            ->setRequired('standard_price')
+            ->setAllowedTypes('standard_price', 'float');
     }
 }

--- a/templates/client/index.html.twig
+++ b/templates/client/index.html.twig
@@ -31,7 +31,6 @@
             <th class="table-th {% if clients.isSorted('client.type') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.type'|trans, 'client.type') }}</th>
             <th class="table-th {% if clients.isSorted('client.psp') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.psp'|trans, 'client.psp') }}</th>
             <th class="table-th {% if clients.isSorted('client.ean') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.ean'|trans, 'client.ean') }}</th>
-            <th class="table-th {% if clients.isSorted('client.standardPrice') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.standardPrice'|trans, 'client.standardPrice') }}</th>
             <th class="table-th {% if clients.isSorted('client.customerKey') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.customer_key'|trans, 'client.customerKey') }}</th>
             <th class="table-th {% if clients.isSorted('client.versionName') %} sorted{% endif %}">{{ knp_pagination_sortable(clients, 'clients.version_name'|trans, 'client.versionName') }}</th>
             <th class="table-th">{{ 'clients.actions'|trans }}</th>
@@ -43,6 +42,7 @@
                 <td class="table-td">{{ client.id }}</td>
                 <td class="table-td">{{ client.name }}</td>
                 <td class="table-td">{{ client.contact }}</td>
+                {# @TODO Format standardPrice as amount #}
                 <td class="table-td">{{ client.standardPrice }}</td>
                 <td class="table-td">{{ client.dataProvider }}</td>
                 {% if client.type is not null %}
@@ -52,8 +52,6 @@
                 {% endif %}
                 <td class="table-td">{{ client.psp }}</td>
                 <td class="table-td">{{ client.ean }}</td>
-                {# @TODO Format standardPrice as amount #}
-                <td class="table-td">{{ client.standardPrice ? client.standardPrice|number_format }}</td>
                 <td class="table-td">{{ client.customerKey }}</td>
                 <td class="table-td">{{ client.versionName }}</td>
                 <td class="table-td">

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -105,7 +105,7 @@ create_client_form:
         help: ""
     client_standardPrice:
         label: "Standardpris"
-        help: ""
+        help: "Hvis standardpris ikke er sat bruges den globale værdi (pt. %standard_price%)"
     type:
         label: "Kundetype"
         help: ""
@@ -596,7 +596,6 @@ clients:
     list_no_records_found: "Ingen kunder"
     data_provider: "Datakilde"
     version_name: 'Version'
-    standardPrice: Standardpris
 
 delete:
     confirm: "Er du sikker på at du vil slette dette?"


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#tickets/showTicket/973

#### Description

Makes standard price optional on client in the UI. If a price on a client is not set, the globally defined price will be used.

#### Screenshot of the result

![Screen Shot 2024-03-20 at 11 06 04](https://github.com/itk-dev/economics/assets/11267554/3c72b39f-e473-474c-be61-8a185b51bc5c)

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
