### PR TITLE
1169: Made sure that Leantime issues have at most one version (milestone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-103](https://github.com/itk-dev/economics/pull/103)
+  1169: Made sure that Leantime issues have at most one version (milestone)
 * [PR-102](https://github.com/itk-dev/economics/pull/102)
   1157: Updated external billing export
 

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -250,7 +250,7 @@ class DataSynchronizationService
                 }
             }
 
-            $startAt += self::MAX_RESULTS;
+            $startAt += $pagedIssueData->maxResults;
 
             $this->entityManager->flush();
             $this->entityManager->clear();

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -231,6 +231,11 @@ class DataSynchronizationService
                 $issue->setResolutionDate($issueDatum->resolutionDate);
                 $issue->setStatus($issueDatum->status);
 
+                // Leantime (as of now) supports only a single version (milestone) per issue.
+                if (LeantimeApiService::class === $dataProvider?->getClass()) {
+                    $issue->getVersions()->clear();
+                }
+
                 foreach ($issueDatum->versions as $versionData) {
                     $version = $this->versionRepository->findOneBy(['projectTrackerId' => $versionData->projectTrackerId]);
 


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/1169

#### Description

* Clears versions on Leantime issue before adding a new version. Leantime supports only one version (milestone) per issue.
* Fixes pagination issue. The Leantime API does not yet support pagination.

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
