### PR TITLE
1202: Handled worklog deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-106](https://github.com/itk-dev/economics/pull/106)
+  1202: Handled worklog deletions
+
 ## [2.1.2] - 2024-04-16
 
 * [PR-104](https://github.com/itk-dev/economics/pull/104)

--- a/migrations/Version20240418085604.php
+++ b/migrations/Version20240418085604.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240418085604 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE worklog ADD deleted_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE worklog DROP deleted_at');
+    }
+}

--- a/src/Entity/Worklog.php
+++ b/src/Entity/Worklog.php
@@ -6,11 +6,15 @@ use App\Entity\Trait\DataProviderTrait;
 use App\Repository\WorklogRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
 
 #[ORM\Entity(repositoryClass: WorklogRepository::class)]
+#[Gedmo\SoftDeleteable()]
 class Worklog extends AbstractBaseEntity
 {
     use DataProviderTrait;
+    use SoftDeleteableEntity;
 
     #[ORM\Column]
     private ?int $worklogId = null;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/1202

#### Description

Handles deleting of project worklogs that are removed in data provider source. Worklogs are soft-deleted so that we have a log of what has been deleted (mostly to satisfy our curiosity).

The check for which project worklogs to delete (https://github.com/itk-dev/economics/pull/106/files#diff-1e5cb9ea1ca2f6886be7660680b3504ab17245b4f872fbb4439fde8f841ef355R289-R302) may need further refinement.

For testing, this command can be used:

```shell
itkdev-docker-compose bin/console app:sync-worklogs -vvv && $(itkdev-docker-compose sql:connect) --table <<< "SELECT id, worklog_id, issue_id, deleted_at FROM worklog WHERE project_id = 362 ORDER BY worklog_id"
```

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
