### PR TITLE
1484: Cleaned up worklog cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-120](https://github.com/itk-dev/economics/pull/120)
+  1484: Cleaned up worklog cleanup
 * [PR-118](https://github.com/itk-dev/economics/pull/118)
   1485: Made product quantity floatable
 


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/1484>

#### Description

Fixes cleanup of worklogs. Previously, the cleanup failed with the exception

>   [Doctrine\ORM\ORMInvalidArgumentException]
  Detached entity App\Entity\Worklog@1022 cannot be removed

due to the [entity manager being cleared](https://github.com/itk-dev/economics/blob/2bd9d069cd182d367e301f1724877579dc49badc/src/Service/DataSynchronizationService.php#L125) during project worklog synchronization.

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
