### PR TITLE
2041: Revise leantime issue status sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-142](https://github.com/itk-dev/economics/pull/142)
+  2041: Revise Leantime issue status sync.
 * [PR-138](https://github.com/itk-dev/economics/pull/138)
   1867: Issue status as enum.
 * [PR-135](https://github.com/itk-dev/economics/pull/135)

--- a/src/Enum/IssueStatusEnum.php
+++ b/src/Enum/IssueStatusEnum.php
@@ -19,6 +19,7 @@ enum IssueStatusEnum: string
     case READY_FOR_TEST = 'ready for test';
     case DONE = 'done';
     case ARCHIVED = 'archived';
+    case OTHER = 'other';
 
     /**
      * @return array<string,string>

--- a/src/Service/JiraApiService.php
+++ b/src/Service/JiraApiService.php
@@ -772,7 +772,8 @@ class JiraApiService implements DataProviderServiceInterface
             return $statusMapping[$statusName];
         }
 
-        throw new \InvalidArgumentException('Invalid status name');
+        // Default fallback for unmatched statuses
+        return IssueStatusEnum::OTHER;
     }
 
     /**

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -74,7 +74,14 @@ class LeantimeApiService implements DataProviderServiceInterface
         return $this->request(self::API_PATH_JSONRPC, 'POST', 'leantime.rpc.projects.getAll', []);
     }
 
-    private function getProjectTicketStatusSettings(string $projectId): mixed
+    /**
+     * Retrieves the ticket status settings for a specific project.
+     *
+     * @param string $projectId the ID of the project
+     *
+     * @return array the ticket status settings of the project
+     */
+    private function getProjectTicketStatusSettings(string $projectId): \stdClass
     {
         return $this->request(self::API_PATH_JSONRPC, 'POST', 'leantime.rpc.tickets.getStatusLabels', ['projectId' => $projectId]);
     }
@@ -204,7 +211,8 @@ class LeantimeApiService implements DataProviderServiceInterface
             return self::STATUS_MAPPING[$statusType];
         }
 
-        throw new \InvalidArgumentException('Invalid status key '.$statusType);
+        // Default fallback for unmatched statuses
+        return IssueStatusEnum::OTHER;
     }
 
     private function getLeanDateTime(string $s): ?\DateTime

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -79,7 +79,7 @@ class LeantimeApiService implements DataProviderServiceInterface
      *
      * @param string $projectId the ID of the project
      *
-     * @return array the ticket status settings of the project
+     * @return \stdClass the ticket status settings of the project
      */
     private function getProjectTicketStatusSettings(string $projectId): \stdClass
     {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/2041

#### Description

After discovering that Leantime issue status is defined per-project instead of being set in stone, the synchronization of leantime-issues needs to be adjusted.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
