### PR TITLE
2050: Hour-report issue duedate ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-143](https://github.com/itk-dev/economics/pull/143)
+  2050: Hour-report issue duedate ignore.
 * [PR-142](https://github.com/itk-dev/economics/pull/142)
   2041: Revise Leantime issue status sync.
 * [PR-138](https://github.com/itk-dev/economics/pull/138)

--- a/src/Service/HourReportService.php
+++ b/src/Service/HourReportService.php
@@ -37,15 +37,14 @@ class HourReportService
 
         foreach ($projectIssues as $issue) {
             $totalTicketEstimated = (float) $issue->planHours;
-            $dueDate = $issue->getDueDate();
 
             $timesheetData = $this->worklogRepository->findBy(['issue' => $issue->getId()]);
 
             list($timesheets, $totalTicketSpent) = $this->processTimesheetsData($timesheetData, $fromDate, $toDate);
 
-            // If no worklogs have been registered in the interval or if the due date is not in the interval,
+            // If no worklogs have been registered in the interval,
             // ignore the issue in the report.
-            if (0 === $totalTicketSpent || $dueDate < $fromDate || $dueDate > $toDate) {
+            if (0 === $totalTicketSpent) {
                 continue;
             }
 
@@ -94,13 +93,13 @@ class HourReportService
             $timesheetDate = $worklog->getStarted();
 
             if (null !== $fromDate) {
-                if ($timesheetDate < $fromDate) {
+                if ($timesheetDate <= $fromDate) {
                     continue;
                 }
             }
 
             if (null !== $toDate) {
-                if ($timesheetDate > $toDate) {
+                if ($timesheetDate >= $toDate) {
                     continue;
                 }
             }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/2050

#### Description

After concluding that missing issue dueDate excludes relevant logs from the Hour Report, it has been decided to remove the issue duedate check from the logic.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
