### PR TITLE
2051: Workload report timezone fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-144](https://github.com/itk-dev/economics/pull/144)
+  2051: Convert worklog workdate timezone from UTC to local.
 * [PR-143](https://github.com/itk-dev/economics/pull/143)
   2050: Hour-report issue duedate ignore.
 * [PR-142](https://github.com/itk-dev/economics/pull/142)

--- a/src/Service/DataProviderService.php
+++ b/src/Service/DataProviderService.php
@@ -29,6 +29,7 @@ class DataProviderService
         protected readonly string $sprintNameRegex,
         protected readonly int $httpClientRetryDelayMs = 1000,
         protected readonly int $httpClientMaxRetries = 3,
+        private readonly DateTimeHelper $dateTimeHelper,
     ) {
     }
 
@@ -82,6 +83,7 @@ class DataProviderService
                     $this->weekGoalLow,
                     $this->weekGoalHigh,
                     $this->sprintNameRegex,
+                    $this->dateTimeHelper
                 );
                 break;
             default:

--- a/src/Service/DateTimeHelper.php
+++ b/src/Service/DateTimeHelper.php
@@ -53,19 +53,27 @@ class DateTimeHelper
     }
 
     /**
-     * Calculate the number of days between two dates in an associative array.
+     * Calculate the number of weekdays (Mon-Fri) between two dates in an associative array.
      *
      * @param array $firstAndLastDate Associative array with 'first' and 'last' keys
+     *
      * @return int
      */
-    public function daysBetween(array $firstAndLastDate): int
+    public function getWeekdaysBetween(array $firstAndLastDate): int
     {
         $date1 = new \DateTime($firstAndLastDate['first']);
         $date2 = new \DateTime($firstAndLastDate['last']);
 
-        $interval = $date1->diff($date2);
+        $weekdays = 0;
+        // Formatted 'N' Monday is 1, Sunday is 7. So, 1-5 will be weekdays
+        while ($date1 <= $date2) {
+            if ($date1->format('N') < 6) {
+                ++$weekdays;
+            }
+            $date1->modify('+1 day');
+        }
 
-        return (int) $interval->format('%a');
+        return $weekdays;
     }
 
     /**
@@ -129,27 +137,5 @@ class DateTimeHelper
         $lastDate = $lastDateTime->format($format);
 
         return ['first' => $firstDate, 'last' => $lastDate];
-    }
-
-    /**
-     * Converts the date to Europe/Copenhagen timezone.
-     *
-     * @param \DateTime|string $datetime
-     *
-     * @return \DateTime
-     */
-    public function convertToLocalTimezone(\DateTime|string $datetime): \DateTime
-    {
-        if (is_string($datetime)) {
-            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $datetime, new \DateTimeZone('UTC'));
-        }
-
-        $datetime->setTimezone(new \DateTimeZone('UTC'));
-
-        if ($datetime instanceof \DateTime) {
-            $datetime->setTimezone(new \DateTimeZone('Europe/Copenhagen'));
-        }
-
-        return $datetime;
     }
 }

--- a/src/Service/DateTimeHelper.php
+++ b/src/Service/DateTimeHelper.php
@@ -53,6 +53,22 @@ class DateTimeHelper
     }
 
     /**
+     * Calculate the number of days between two dates in an associative array.
+     *
+     * @param array $firstAndLastDate Associative array with 'first' and 'last' keys
+     * @return int
+     */
+    public function daysBetween(array $firstAndLastDate): int
+    {
+        $date1 = new \DateTime($firstAndLastDate['first']);
+        $date2 = new \DateTime($firstAndLastDate['last']);
+
+        $interval = $date1->diff($date2);
+
+        return (int) $interval->format('%a');
+    }
+
+    /**
      * Retrieves an array of week numbers for a given year.
      *
      * @param int $year the year for which to retrieve the week numbers

--- a/src/Service/DateTimeHelper.php
+++ b/src/Service/DateTimeHelper.php
@@ -114,4 +114,26 @@ class DateTimeHelper
 
         return ['first' => $firstDate, 'last' => $lastDate];
     }
+
+    /**
+     * Converts the date to Europe/Copenhagen timezone.
+     *
+     * @param \DateTime|string $datetime
+     *
+     * @return \DateTime
+     */
+    public function convertToLocalTimezone(\DateTime|string $datetime): \DateTime
+    {
+        if (is_string($datetime)) {
+            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $datetime, new \DateTimeZone('UTC'));
+        }
+
+        $datetime->setTimezone(new \DateTimeZone('UTC'));
+
+        if ($datetime instanceof \DateTime) {
+            $datetime->setTimezone(new \DateTimeZone('Europe/Copenhagen'));
+        }
+
+        return $datetime;
+    }
 }

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -322,14 +322,12 @@ class LeantimeApiService implements DataProviderServiceInterface
 
         foreach ($worklogs as $worklog) {
             $worklogData = new WorklogData();
-            // All dates retrieved from Leantime is UTC, therefore convert it to local timezone
-            $workDate = $this->dateTimeHelper->convertToLocalTimezone($worklog->workDate);
             if (isset($worklog->ticketId)) {
                 $worklogData->projectTrackerId = $worklog->id;
                 $worklogData->comment = $worklog->description ?? '';
                 $worklogData->worker = $workers[$worklog->userId] ?? $worklog->userId;
                 $worklogData->timeSpentSeconds = (int) ($worklog->hours * 60 * 60);
-                $worklogData->started = $workDate;
+                $worklogData->started = $worklog->workDate;
                 $worklogData->projectTrackerIsBilled = false;
                 $worklogData->projectTrackerIssueId = $worklog->ticketId;
                 $worklogData->kind = $worklog->kind;

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -54,6 +54,7 @@ class LeantimeApiService implements DataProviderServiceInterface
         protected readonly float $weekGoalLow,
         protected readonly float $weekGoalHigh,
         protected readonly string $sprintNameRegex,
+        private readonly DateTimeHelper $dateTimeHelper,
     ) {
     }
 
@@ -321,12 +322,14 @@ class LeantimeApiService implements DataProviderServiceInterface
 
         foreach ($worklogs as $worklog) {
             $worklogData = new WorklogData();
+            // All dates retrieved from Leantime is UTC, therefore convert it to local timezone
+            $workDate = $this->dateTimeHelper->convertToLocalTimezone($worklog->workDate);
             if (isset($worklog->ticketId)) {
                 $worklogData->projectTrackerId = $worklog->id;
                 $worklogData->comment = $worklog->description ?? '';
                 $worklogData->worker = $workers[$worklog->userId] ?? $worklog->userId;
                 $worklogData->timeSpentSeconds = (int) ($worklog->hours * 60 * 60);
-                $worklogData->started = new \DateTime($worklog->workDate);
+                $worklogData->started = $workDate;
                 $worklogData->projectTrackerIsBilled = false;
                 $worklogData->projectTrackerIssueId = $worklog->ticketId;
                 $worklogData->kind = $worklog->kind;

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -77,9 +77,9 @@ class WorkloadReportService
                     $workerId = $worker->getUserIdentifier();
                     throw new \Exception("Workload of worker: $workerId cannot be unset when generating workload report.");
                 }
-
                 // Get total logged percentage based on weekly workload.
                 $roundedLoggedPercentage = $this->getRoundedLoggedPercentage($loggedHours, $workerWorkload, $viewPeriodType, $firstAndLastDate);
+
                 // Add percentage result to worker for current period.
                 $workloadReportWorker->loggedPercentage->set($period, $roundedLoggedPercentage);
             }
@@ -103,8 +103,8 @@ class WorkloadReportService
         // Workload is weekly hours, so for expanded views, it has to be multiplied.
         return match ($viewPeriodType) {
             PeriodTypeEnum::WEEK => round(($loggedHours / $workloadWeekBase) * 100),
-            PeriodTypeEnum::MONTH => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->daysBetween($firstAndLastDate) / 7))) * 100),
-            PeriodTypeEnum::YEAR => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->daysBetween($firstAndLastDate) / 7))) * 100, 2),
+            PeriodTypeEnum::MONTH => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->getWeekdaysBetween($firstAndLastDate) / 5))) * 100),
+            PeriodTypeEnum::YEAR => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->getWeekdaysBetween($firstAndLastDate) / 5))) * 100, 2),
         };
     }
 

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -79,7 +79,7 @@ class WorkloadReportService
                 }
 
                 // Get total logged percentage based on weekly workload.
-                $roundedLoggedPercentage = $this->getRoundedLoggedPercentage($loggedHours, $workerWorkload, $viewPeriodType);
+                $roundedLoggedPercentage = $this->getRoundedLoggedPercentage($loggedHours, $workerWorkload, $viewPeriodType, $firstAndLastDate);
                 // Add percentage result to worker for current period.
                 $workloadReportWorker->loggedPercentage->set($period, $roundedLoggedPercentage);
             }
@@ -98,13 +98,13 @@ class WorkloadReportService
      *
      * @return float the rounded percentage of logged hours
      */
-    private function getRoundedLoggedPercentage(float $loggedHours, float $workloadWeekBase, PeriodTypeEnum $viewPeriodType): float
+    private function getRoundedLoggedPercentage(float $loggedHours, float $workloadWeekBase, PeriodTypeEnum $viewPeriodType, array $firstAndLastDate): float
     {
         // Workload is weekly hours, so for expanded views, it has to be multiplied.
         return match ($viewPeriodType) {
             PeriodTypeEnum::WEEK => round(($loggedHours / $workloadWeekBase) * 100),
-            PeriodTypeEnum::MONTH => round(($loggedHours / ($workloadWeekBase * 4)) * 100),
-            PeriodTypeEnum::YEAR => round(($loggedHours / ($workloadWeekBase * 52)) * 100, 2),
+            PeriodTypeEnum::MONTH => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->daysBetween($firstAndLastDate) / 7))) * 100),
+            PeriodTypeEnum::YEAR => round(($loggedHours / ($workloadWeekBase * ($this->dateTimeHelper->daysBetween($firstAndLastDate) / 7))) * 100, 2),
         };
     }
 

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -76,6 +76,9 @@ class WorkloadReportServiceTest extends TestCase
             'first' => '2024-01-01 00:00:00',
             'last' => '2024-12-31 23:59:59',
         ]);
+        $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(5);
+        $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(23);
+        $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(262);
 
         $workloadReportService = new WorkloadReportService($workerRepoMock, $worklogRepoMock, $dateTimeHelperMock);
 


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/2051

#### Description

Since Leantime converts all Worklog registration dates to UTC, the timezone needs to be restored to the local timezone when worklogs are synchronized to Ecnomics, since ex:

2024-08-06 00:00:00 becomes 2024-08-05 22:00:00 and offsets the numbers in the view, causing an incorrect data rendition.

Leantime does not offer to convert it back before delivering the data. Therefore we need a method to do it ourselves.

Furthermore, the division of workload hours to get month and year view needs to be specified further.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
