### PR TITLE
HourReport setting default data provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-149](https://github.com/itk-dev/economics/pull/149)
+  2096: Set default dataprovider on hourReport.
 * [PR-148](https://github.com/itk-dev/economics/pull/148)
   2031: Project overview standard settings.
 * [PR-147](https://github.com/itk-dev/economics/pull/147)

--- a/src/Form/HourReportType.php
+++ b/src/Form/HourReportType.php
@@ -21,11 +21,19 @@ class HourReportType extends AbstractType
     public function __construct(
         private readonly HourReportService $hourReportService,
         private readonly DataProviderRepository $dataProviderRepository,
+        private readonly ?string $defaultDataProvider,
     ) {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $dataProviders = $this->dataProviderRepository->findAll();
+        $defaultProvider = $this->dataProviderRepository->find($this->defaultDataProvider);
+
+        if (null === $defaultProvider && count($dataProviders) > 0) {
+            $defaultProvider = $dataProviders[0];
+        }
+
         $builder
             ->add('dataProvider', EntityType::class, [
                 'class' => DataProvider::class,
@@ -38,7 +46,8 @@ class HourReportType extends AbstractType
                     'class' => 'form-element',
                 ],
                 'help' => 'sprint_report.data_provider_helptext',
-                'choices' => $this->dataProviderRepository->findAll(),
+                'data' => $defaultProvider,
+                'choices' => $dataProviders,
             ])
             ->add('project', EntityType::class, [
                 'class' => Project::class,


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/2096

#### Description

The default dataprovider is already set in backend, but not in frontend. This PR serves to fix that.

#### Screenshot of the result

<img width="520" alt="Screenshot 2024-08-15 at 09 30 22" src="https://github.com/user-attachments/assets/70c8da23-b212-4247-bc60-e16c1281ac5b">

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
