### PR TITLE
Hotfix: Invoice worklog entry table width

### DIFF
--- a/templates/invoice_entry/worklogs.html.twig
+++ b/templates/invoice_entry/worklogs.html.twig
@@ -22,7 +22,7 @@
 
     <div {{ stimulus_controller('entry-select') }} data-submit-endpoint="{{ submitEndpoint }}">
         <form id="entry-form">
-            <table class="table margin-bottom">
+            <table class="table margin-bottom table-fixed">
                 <thead class="table-th">
                 <tr>
                     <th class="table-th">


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Fixes the width of a specific table that increases the width of the Invoice Worklog Entry page in an unwanted way.

#### Screenshot of the result

Before:
<img width="1552" alt="Screenshot 2024-08-16 at 10 46 55" src="https://github.com/user-attachments/assets/b2392003-79fc-4442-a7eb-108e816a66a9">

After:
<img width="1577" alt="Screenshot 2024-08-16 at 10 47 04" src="https://github.com/user-attachments/assets/2151c4cf-d472-424e-b62b-66cdcfd1b1af">

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
