### PR TITLE
Feature/2244 handling leantime timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-152](https://github.com/itk-dev/economics/pull/152)
+  2244: Handling Leantime timestamps when importing.
+
 ## [2.4.0] - 2024-08-20
 
 * [PR-149](https://github.com/itk-dev/economics/pull/149)

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,6 +1,9 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        types:
+            datetime: App\Doctrine\Extensions\DBAL\Types\EuropeCopenhagenDateTimeType
+            datetime_immutable: App\Doctrine\Extensions\DBAL\Types\EuropeCopenhagenDateTimeImmutableType
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeImmutableType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeImmutableType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Doctrine\Extensions\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+
+class EuropeCopenhagenDateTimeImmutableType extends DateTimeImmutableType
+{
+    private static \DateTimeZone $europeCopenhagenTimeZone;
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            if (self::getEuropeCopenhagenTimeZone()->getName() !== $value->getTimezone()->getName()) {
+                $mutable = \DateTime::createFromImmutable($value);
+                $mutable->setTimezone(self::getEuropeCopenhagenTimeZone());
+
+                $value = \DateTimeImmutable::createFromMutable($mutable);
+            }
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?\DateTimeImmutable
+    {
+        if (null === $value || $value instanceof \DateTimeImmutable) {
+            return $value;
+        }
+
+        $converted = \DateTimeImmutable::createFromFormat(
+            $platform->getDateTimeFormatString(),
+            $value,
+            self::getEuropeCopenhagenTimeZone()
+        );
+
+        if (false === $converted) {
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());
+        }
+
+        return $converted;
+    }
+
+    private static function getEuropeCopenhagenTimeZone(): \DateTimeZone
+    {
+        return self::$europeCopenhagenTimeZone ??= new \DateTimeZone('Europe/Copenhagen');
+    }
+}

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeImmutableType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeImmutableType.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Types\DateTimeImmutableType;
 
 class EuropeCopenhagenDateTimeImmutableType extends DateTimeImmutableType
 {
-    private static \DateTimeZone $europeCopenhagenTimeZone;
+    private static ?\DateTimeZone $europeCopenhagenTimeZone = null;
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
@@ -45,6 +45,10 @@ class EuropeCopenhagenDateTimeImmutableType extends DateTimeImmutableType
 
     private static function getEuropeCopenhagenTimeZone(): \DateTimeZone
     {
-        return self::$europeCopenhagenTimeZone ??= new \DateTimeZone('Europe/Copenhagen');
+        if (null === self::$europeCopenhagenTimeZone) {
+            self::$europeCopenhagenTimeZone = new \DateTimeZone('Europe/Copenhagen');
+        }
+
+        return self::$europeCopenhagenTimeZone;
     }
 }

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
@@ -19,8 +19,12 @@ class EuropeCopenhagenDateTimeType extends DateTimeType
         return parent::convertToDatabaseValue($value, $platform);
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform): \DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?\DateTimeInterface
     {
+        if (null === $value) {
+            return null;
+        }
+
         if ($value instanceof \DateTime) {
             return $value;
         }

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Types\DateTimeType;
 
 class EuropeCopenhagenDateTimeType extends DateTimeType
 {
-    private static \DateTimeZone $europeCopenhagenTimeZone;
+    private static ?\DateTimeZone $europeCopenhagenTimeZone = null;
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
@@ -40,6 +40,10 @@ class EuropeCopenhagenDateTimeType extends DateTimeType
 
     private static function getEuropeCopenhagenTimeZone(): \DateTimeZone
     {
-        return self::$europeCopenhagenTimeZone ??= new \DateTimeZone('Europe/Copenhagen');
+        if (null === self::$europeCopenhagenTimeZone) {
+            self::$europeCopenhagenTimeZone = new \DateTimeZone('Europe/Copenhagen');
+        }
+
+        return self::$europeCopenhagenTimeZone;
     }
 }

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
@@ -19,9 +19,9 @@ class EuropeCopenhagenDateTimeType extends DateTimeType
         return parent::convertToDatabaseValue($value, $platform);
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?\DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform): \DateTime
     {
-        if (null === $value || $value instanceof \DateTime) {
+        if ($value instanceof \DateTime) {
             return $value;
         }
 

--- a/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
+++ b/src/Doctrine/Extensions/DBAL/Types/EuropeCopenhagenDateTimeType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Doctrine\Extensions\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateTimeType;
+
+class EuropeCopenhagenDateTimeType extends DateTimeType
+{
+    private static \DateTimeZone $europeCopenhagenTimeZone;
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof \DateTime) {
+            $value->setTimezone(self::getEuropeCopenhagenTimeZone());
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?\DateTime
+    {
+        if (null === $value || $value instanceof \DateTime) {
+            return $value;
+        }
+
+        $converted = \DateTime::createFromFormat(
+            $platform->getDateTimeFormatString(),
+            $value,
+            self::getEuropeCopenhagenTimeZone()
+        );
+
+        if (false === $converted) {
+            throw ConversionException::conversionFailedFormat($value, $this->getName(), $platform->getDateTimeFormatString());
+        }
+
+        return $converted;
+    }
+
+    private static function getEuropeCopenhagenTimeZone(): \DateTimeZone
+    {
+        return self::$europeCopenhagenTimeZone ??= new \DateTimeZone('Europe/Copenhagen');
+    }
+}

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -41,6 +41,10 @@ class LeantimeApiService implements DataProviderServiceInterface
     private const PRESENT = 'PRESENT';
     private const FUTURE = 'FUTURE';
 
+    private const LEANTIME_TIMEZONE = 'UTC';
+
+    private static \DateTimeZone $leantimeTimeZone;
+
     private const STATUS_MAPPING = [
         'NEW' => IssueStatusEnum::NEW,
         'INPROGRESS' => IssueStatusEnum::IN_PROGRESS,
@@ -190,7 +194,7 @@ class LeantimeApiService implements DataProviderServiceInterface
             $issueData->epicName = $issue->tags;
             $issueData->planHours = $issue->planHours;
             $issueData->hourRemaining = $issue->hourRemaining;
-            $issueData->dueDate = !empty($issue->dateToFinish) && '0000-00-00 00:00:00' !== $issue->dateToFinish ? new \DateTime($issue->dateToFinish) : null;
+            $issueData->dueDate = !empty($issue->dateToFinish) && '0000-00-00 00:00:00' !== $issue->dateToFinish ? new \DateTime($issue->dateToFinish, self::getLeantimeTimeZone()) : null;
             if (isset($issue->milestoneid) && isset($issue->milestoneHeadline)) {
                 $issueData->versions?->add(new VersionData($issue->milestoneid, $issue->milestoneHeadline));
             }
@@ -327,7 +331,7 @@ class LeantimeApiService implements DataProviderServiceInterface
                 $worklogData->comment = $worklog->description ?? '';
                 $worklogData->worker = $workers[$worklog->userId] ?? $worklog->userId;
                 $worklogData->timeSpentSeconds = (int) ($worklog->hours * 60 * 60);
-                $worklogData->started = new \DateTime($worklog->workDate);
+                $worklogData->started = new \DateTime($worklog->workDate, self::getLeantimeTimeZone());
                 $worklogData->projectTrackerIsBilled = false;
                 $worklogData->projectTrackerIssueId = $worklog->ticketId;
                 $worklogData->kind = $worklog->kind;
@@ -844,5 +848,10 @@ class LeantimeApiService implements DataProviderServiceInterface
         } else {
             return self::FUTURE;
         }
+    }
+
+    private function getLeantimeTimeZone(): \DateTimeZone
+    {
+        return self::$leantimeTimeZone ??= new \DateTimeZone(self::LEANTIME_TIMEZONE);
     }
 }

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -43,7 +43,7 @@ class LeantimeApiService implements DataProviderServiceInterface
 
     private const LEANTIME_TIMEZONE = 'UTC';
 
-    private static \DateTimeZone $leantimeTimeZone;
+    private static ?\DateTimeZone $leantimeTimeZone = null;
 
     private const STATUS_MAPPING = [
         'NEW' => IssueStatusEnum::NEW,
@@ -852,6 +852,10 @@ class LeantimeApiService implements DataProviderServiceInterface
 
     private function getLeantimeTimeZone(): \DateTimeZone
     {
-        return self::$leantimeTimeZone ??= new \DateTimeZone(self::LEANTIME_TIMEZONE);
+        if (null === self::$leantimeTimeZone) {
+            self::$leantimeTimeZone = new \DateTimeZone(self::LEANTIME_TIMEZONE);
+        }
+
+        return self::$leantimeTimeZone;
     }
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?showTicketModal=2244#/tickets/showTicket/2244

#### Description

Settings up doctrine extension to always convert dates to Europe/Copenhagen timezone. Explicit setting timezone as UTC for Leantime dates, allows the correct dates to be synced into Economics.

- **Added extensions for doctrine for handling conversion of dates to Europe/Copenhagen (thanks to Ture)**
- **Added config for doctrine extension files**
- **Set Leantime api dates to UTC when syncing for new doctrine functionality to work**

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
