### PR TITLE
feature/2396 planning view year selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-159](https://github.com/itk-dev/economics/pull/159)
+  2396: Added year select to planning overview.
 * [PR-158](https://github.com/itk-dev/economics/pull/158)
   2299: Fixed isBillable filter for project list.
   2299: Removed unused code from planning overviews.

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -2,8 +2,11 @@
 
 namespace App\Controller;
 
+use App\Form\PlanningType;
+use App\Model\Planning\PlanningFormData;
 use App\Service\PlanningService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -17,31 +20,69 @@ class PlanningController extends AbstractController
     ) {
     }
 
+    /**
+     * @throws \Exception
+     */
+    private function preparePlaningData(Request $request): array
+    {
+        $planningFormData = new PlanningFormData();
+        $planningFormData->year = (new \DateTime())->format('Y');
+        $form = $this->createForm(PlanningType::class, $planningFormData, [
+            'action' => $this->generateUrl('app_planning'),
+            'attr' => [
+                'id' => 'sprint_report',
+            ],
+            'years' => [(new \DateTime())->format('Y'), (new \DateTime())->modify('+1 year')->format('Y')],
+            'method' => 'GET',
+            'csrf_protection' => false,
+        ]);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $planningFormData = $form->getData();
+        }
+
+        $planningData = $this->planningService->getPlanningData($planningFormData->year);
+
+        return ['planningData' => $planningData, 'form' => $form, 'year' => $planningFormData->year];
+    }
+
     #[Route('/', name: 'app_planning')]
     public function index(): Response
     {
         return $this->redirectToRoute('app_planning_users');
     }
 
+    /**
+     * @throws \Exception
+     */
     #[Route('/users', name: 'app_planning_users')]
-    public function planningUsers(): Response
+    public function planningUsers(Request $request): Response
     {
-        return $this->createResponse('users');
+        $data = $this->preparePlaningData($request);
+
+        return $this->createResponse('users', $data);
     }
 
+    /**
+     * @throws \Exception
+     */
     #[Route('/projects', name: 'app_planning_projects')]
-    public function planningProjects(): Response
+    public function planningProjects(Request $request): Response
     {
-        return $this->createResponse('projects');
+        $data = $this->preparePlaningData($request);
+
+        return $this->createResponse('projects', $data);
     }
 
-    private function createResponse(string $mode): Response
+    private function createResponse(string $mode, array $data): Response
     {
-        $planningData = $this->planningService->getPlanningData();
-
         return $this->render('planning/planning.html.twig', [
             'controller_name' => 'PlanningController',
-            'planningData' => $planningData,
+            'planningData' => $data['planningData'],
+            'form' => $data['form'],
+            'year' => $data['year'],
             'mode' => $mode,
         ]);
     }

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -26,9 +26,9 @@ class PlanningController extends AbstractController
     private function preparePlaningData(Request $request): array
     {
         $planningFormData = new PlanningFormData();
-        $planningFormData->year = (new \DateTime())->format('Y');
+        $planningFormData->year = (int) (new \DateTime())->format('Y');
         $form = $this->createForm(PlanningType::class, $planningFormData, [
-            'action' => $this->generateUrl('app_planning'),
+            'action' => $this->generateUrl($request->attributes->get('_route')),
             'attr' => [
                 'id' => 'sprint_report',
             ],

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -23,7 +23,7 @@ class PlanningController extends AbstractController
     /**
      * @throws \Exception
      */
-    private function preparePlaningData(Request $request): array
+    private function preparePlanningData(Request $request): array
     {
         $planningFormData = new PlanningFormData();
         $planningFormData->year = (int) (new \DateTime())->format('Y');
@@ -60,7 +60,7 @@ class PlanningController extends AbstractController
     #[Route('/users', name: 'app_planning_users')]
     public function planningUsers(Request $request): Response
     {
-        $data = $this->preparePlaningData($request);
+        $data = $this->preparePlanningData($request);
 
         return $this->createResponse('users', $data);
     }
@@ -71,7 +71,7 @@ class PlanningController extends AbstractController
     #[Route('/projects', name: 'app_planning_projects')]
     public function planningProjects(Request $request): Response
     {
-        $data = $this->preparePlaningData($request);
+        $data = $this->preparePlanningData($request);
 
         return $this->createResponse('projects', $data);
     }

--- a/src/Form/PlanningType.php
+++ b/src/Form/PlanningType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Model\Planning\PlanningFormData;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -11,8 +12,20 @@ class PlanningType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        [$currentYear, $nextYear] = $options['years'];
+
         $builder
-            ->add('dataProvider')
+            ->add('year', ChoiceType::class, [
+                'label' => 'planning.year',
+                'label_attr' => ['class' => 'label'],
+                'attr' => ['class' => 'form-element ', 'data-choices-target' => 'choices', 'onchange' => 'this.form.submit()'],
+                'help_attr' => ['class' => 'form-help'],
+                'row_attr' => ['class' => 'form-row form-choices'],
+                'required' => false,
+                'data' => $currentYear,
+                'choices' => [$currentYear => $currentYear, $nextYear => $nextYear],
+                'placeholder' => null,
+            ])
         ;
     }
 
@@ -23,6 +36,7 @@ class PlanningType extends AbstractType
             'attr' => [
                 'class' => 'form-default',
             ],
+            'years' => null,
         ]);
     }
 }

--- a/src/Form/PlanningType.php
+++ b/src/Form/PlanningType.php
@@ -18,9 +18,9 @@ class PlanningType extends AbstractType
             ->add('year', ChoiceType::class, [
                 'label' => 'planning.year',
                 'label_attr' => ['class' => 'label'],
-                'attr' => ['class' => 'form-element ', 'data-choices-target' => 'choices', 'onchange' => 'this.form.submit()'],
+                'attr' => ['class' => 'form-element ', 'onchange' => 'this.form.submit()'],
                 'help_attr' => ['class' => 'form-help'],
-                'row_attr' => ['class' => 'form-row form-choices'],
+                'row_attr' => ['class' => 'form-row'],
                 'required' => false,
                 'data' => $currentYear,
                 'choices' => [$currentYear => $currentYear, $nextYear => $nextYear],

--- a/src/Model/Planning/PlanningFormData.php
+++ b/src/Model/Planning/PlanningFormData.php
@@ -7,5 +7,5 @@ use App\Entity\DataProvider;
 class PlanningFormData
 {
     public DataProvider $dataProvider;
-    public string $viewType;
+    public int $year;
 }

--- a/src/Service/PlanningService.php
+++ b/src/Service/PlanningService.php
@@ -31,14 +31,16 @@ class PlanningService
      * Retrieves the planning data containing the weeks, issues, assignees, and projects.
      *
      * @return PlanningData The planning data object
+     *
+     * @throws \Exception
      */
-    public function getPlanningData(): PlanningData
+    public function getPlanningData(int $selectedYear): PlanningData
     {
         $planning = new PlanningData();
-        $planning->weeks = $this->buildPlanningWeeks($planning);
+        $planning->weeks = $this->buildPlanningWeeks($planning, $selectedYear);
 
-        $thisYear = (new \DateTime('first day of January this year'))->setTime(0, 0)->format('Y-m-d H:i:s');
-        $nextYear = (new \DateTime('first day of January next year'))->setTime(0, 0)->format('Y-m-d H:i:s');
+        $thisYear = (new \DateTime('first day of January '.$selectedYear))->setTime(0, 0)->format('Y-m-d H:i:s');
+        $nextYear = (new \DateTime('first day of January '.($selectedYear + 1)))->setTime(0, 0)->format('Y-m-d H:i:s');
 
         $allIssues = $this->issueRepository->findIssuesInDateRange($thisYear, $nextYear);
         $sortedIssues = $this->sortIssuesByWeek($allIssues);
@@ -60,15 +62,14 @@ class PlanningService
      *
      * @return ArrayCollection<string, Weeks> The ArrayCollection of Weeks objects representing the weeks in the planning
      */
-    private function buildPlanningWeeks(PlanningData $planning): ArrayCollection
+    private function buildPlanningWeeks(PlanningData $planning, int $year): ArrayCollection
     {
         $weeks = $planning->weeks;
 
         $now = new \DateTime();
-        $currentYear = (int) $now->format('Y');
-        $currentWeek = (int) $now->format('W');
+        $currentWeek = ($year !== (int) $now->format('Y')) ? null : (int) $now->format('W');
 
-        $weeksOfYear = $this->dateTimeHelper->getWeeksOfYear($currentYear);
+        $weeksOfYear = $this->dateTimeHelper->getWeeksOfYear($year);
         foreach ($weeksOfYear as $week) {
             $weekIsSupport = 1 === $week % (self::WEEKS_IN_SUPPORT_PERIOD + self::WEEKS_IN_SPRINT_PERIOD);
 

--- a/templates/planning/planning.html.twig
+++ b/templates/planning/planning.html.twig
@@ -9,7 +9,6 @@
 
     {{ form_start(form) }}
         {{ form_rest(form) }}
-
     {{ form_end(form) }}
 
     {% if planningData is not null %}

--- a/templates/planning/planning.html.twig
+++ b/templates/planning/planning.html.twig
@@ -7,6 +7,11 @@
 {% block content %}
     <h1 class="page-title">{{ title }}</h1>
 
+    {{ form_start(form) }}
+        {{ form_rest(form) }}
+
+    {{ form_end(form) }}
+
     {% if planningData is not null %}
         {% set weeks = planningData.weeks %}
         {% set assignees = planningData.assignees %}

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -75,6 +75,7 @@ planning:
     week_view: "Ugevisning"
     sprint_view: "Sprintvisning"
     description: 'Vælg visning'
+    year: 'Vælg år'
 
 client:
     title: "Kunder"


### PR DESCRIPTION
#### Link to ticket

[#2396](https://leantime.itkdev.dk/#/tickets/showTicket/2396)

#### Description

A year select has been added to the Planning Overview in order to make the user able to view planning across multiple years.

#### Screenshot of the result

<img width="1106" alt="Screenshot 2024-09-11 at 10 24 08" src="https://github.com/user-attachments/assets/d426af6c-7ca6-41cb-9c65-42196b33357e">

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
