### PR TITLE
Workload report performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-170](https://github.com/itk-dev/economics/pull/170)
+  Reduced workload report load time.
 * [PR-167](https://github.com/itk-dev/economics/pull/167)
   2499: Added worker name in workload report.
 * [PR-166](https://github.com/itk-dev/economics/pull/166)
   2545: Added total column for workload report.
   2545: Fixed average calculation.
 * [PR-168](https://github.com/itk-dev/economics/pull/168)
-  Added Game center
+  Added Game center.
 * [PR-164](https://github.com/itk-dev/economics/pull/164)
-  3298: Added report notification subscription
+  3298: Added report notification subscription.
 
 ## [2.4.2] - 2024-09-12
 

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -437,15 +437,9 @@
         display: none;
     }
     .subscribe-button:before {
+        @apply absolute left-0 w-full text-sm text-right pointer-events-none dark:text-white;
         content: 'Subscribed ' attr(data-frequencies);
-        color: rgb(255 255 255 / var(--tw-text-opacity));
-        position: absolute;
         top: -20px;
-        left: 0;
-        width: 100%;
-        font-size: 14px;
-        text-align: right;
-        pointer-events: none;
     }
     .subscribe-button svg {
         display: inline-block;

--- a/src/Repository/WorklogRepository.php
+++ b/src/Repository/WorklogRepository.php
@@ -96,7 +96,7 @@ class WorklogRepository extends ServiceEntityRepository
         return $qb->getQuery()->execute();
     }
 
-    public function findWorklogsByDateRange( \DateTime $dateFrom, \DateTime $dateTo): array
+    public function findWorklogsByDateRange(\DateTime $dateFrom, \DateTime $dateTo): array
     {
         $qb = $this->createQueryBuilder('worklog');
 

--- a/src/Service/DateTimeHelper.php
+++ b/src/Service/DateTimeHelper.php
@@ -137,6 +137,11 @@ class DateTimeHelper
         $dateTo = (new \DateTime())->setDate($year, 12, 31);
         $dateTo->setTime(23, 59, 59);
 
-        return ['dateFrom' => $dateFrom, 'dateTo' => $dateTo];
+        return [
+            $year => [
+                'dateFrom' => $dateFrom,
+                'dateTo' => $dateTo,
+            ],
+        ];
     }
 }

--- a/src/Service/DateTimeHelper.php
+++ b/src/Service/DateTimeHelper.php
@@ -9,41 +9,51 @@ class DateTimeHelper
     }
 
     /**
-     * Retrieves the first and last date of a given week number in a year.
+     * Retrieves the first and last date of a given week numbers in a year.
      *
-     * @param int $weekNumber the week number for which to retrieve the dates
+     * @param array $weekNumbers the week numbers for which to retrieve the dates
      * @param int $year the year for which to retrieve the dates
      *
-     * @return array an array containing the first and last date of the week
+     * @return array an array containing the first and last date of each week, keyed by week number
      */
-    public function getFirstAndLastDateOfWeek(int $weekNumber, int $year): array
+    public function getFirstAndLastDatesOfWeeks(array $weekNumbers, int $year): array
     {
-        $dateFrom = (new \DateTime())->setISODate($year, $weekNumber, 1);
-        $dateFrom->setTime(0, 0, 0);
+        $dates = [];
+        foreach ($weekNumbers as $weekNumber) {
+            $dateFrom = (new \DateTime())->setISODate($year, $weekNumber, 1);
+            $dateFrom->setTime(0, 0, 0);
 
-        $dateTo = (new \DateTime())->setISODate($year, $weekNumber, 7);
-        $dateTo->setTime(23, 59, 59);
+            $dateTo = (new \DateTime())->setISODate($year, $weekNumber, 7);
+            $dateTo->setTime(23, 59, 59);
 
-        return ['dateFrom' => $dateFrom, 'dateTo' => $dateTo];
+            $dates[$weekNumber] = ['dateFrom' => $dateFrom, 'dateTo' => $dateTo];
+        }
+
+        return $dates;
     }
 
     /**
-     * Returns the first and last date of the specified month and year.
+     * Returns an array with the first and last date of the specified months.
      *
-     * @param int $monthNumber the month number (1-12)
+     * @param array $monthNumbers
      * @param int $year the year
      *
      * @return array an array containing the first and last date of the specified month and year
      */
-    public function getFirstAndLastDateOfMonth(int $monthNumber, int $year): array
+    public function getFirstAndLastDatesOfMonths(array $monthNumbers, int $year): array
     {
-        $dateFrom = (new \DateTime())->setDate($year, $monthNumber, 1);
-        $dateFrom->setTime(0, 0, 0);
+        $dates = [];
+        foreach ($monthNumbers as $monthNumber) {
+            $dateFrom = (new \DateTime())->setDate($year, $monthNumber, 1);
+            $dateFrom->setTime(0, 0, 0);
 
-        $dateTo = (new \DateTime())->setDate($year, $monthNumber, 1)->modify('last day of this month');
-        $dateTo->setTime(23, 59, 59);
+            $dateTo = (new \DateTime())->setDate($year, $monthNumber, 1)->modify('last day of this month');
+            $dateTo->setTime(23, 59, 59);
 
-        return ['dateFrom' => $dateFrom, 'dateTo' => $dateTo];
+            $dates[$monthNumber] = ['dateFrom' => $dateFrom, 'dateTo' => $dateTo];
+        }
+
+        return $dates;
     }
 
     /**

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -30,7 +30,6 @@ class WorkloadReportService
      */
     public function getWorkloadReport(PeriodTypeEnum $viewPeriodType = PeriodTypeEnum::WEEK, ViewModeEnum $viewMode = ViewModeEnum::WORKLOAD): WorkloadReportData
     {
-        $startTime = microtime(true);
         $workloadReportData = new WorkloadReportData($viewPeriodType->value);
         $year = (int) (new \DateTime())->format('Y');
         $workers = $this->workerRepository->findAll();
@@ -110,9 +109,6 @@ class WorkloadReportService
             $workloadReportData->workers->add($workloadReportWorker);
         }
 
-        /*    $endTime = microtime(true);
-            $executionTime = ($endTime - $startTime);
-            die( "This script took $executionTime seconds to run.");*/
         return $workloadReportData;
     }
 

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -42,8 +42,7 @@ class WorkloadReportService
         $periodsWithDatesArray = $this->getDatesOfPeriods($periods, $year, $viewPeriodType);
 
         // To get all worklogs, we need the first and last datetime of the year
-        $firstDateFrom = current($periodsWithDatesArray)['dateFrom'];
-        $lastDateTo = end($periodsWithDatesArray)['dateTo'];
+        [$firstDateFrom, $lastDateTo] = $this->getFirstAndLastYearDates($periodsWithDatesArray);
 
         $allWorklogs = $this->getWorklogs($viewMode, $firstDateFrom, $lastDateTo);
 
@@ -203,5 +202,29 @@ class WorkloadReportService
             ViewModeEnum::WORKLOAD => $this->worklogRepository->findWorklogsByDateRange($dateFrom, $dateTo),
             ViewModeEnum::BILLABLE => $this->worklogRepository->findBillableWorklogsByDateRange($dateFrom, $dateTo),
         };
+    }
+
+    /**
+     * Gets the first and last date times across the array.
+     *
+     * @param array $datesArray
+     *
+     * @return array
+     *
+     * @throws \Exception
+     */
+    private function getFirstAndLastYearDates(array $datesArray): array
+    {
+        if (empty($datesArray)) {
+            throw new \Exception('Dates array cannot be empty');
+        }
+
+        $firstDatesArray = array_values($datesArray);
+        $firstDateFrom = $firstDatesArray[0]['dateFrom'];
+
+        $lastDatesArray = array_values(array_reverse($datesArray));
+        $lastDateTo = $lastDatesArray[0]['dateTo'];
+
+        return [$firstDateFrom, $lastDateTo];
     }
 }

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -77,7 +77,6 @@ class WorkloadReportService
                 }
                 $worklogs = $allWorklogs[$workerIdentifier] ?? [];
 
-
                 // Tally up logged hours in gathered worklogs for current period
                 $loggedHours = 0;
                 foreach ($worklogs as $worklog) {

--- a/templates/reports/reports.html.twig
+++ b/templates/reports/reports.html.twig
@@ -9,7 +9,7 @@
 
     {% if data is not empty %}
         {{ include('components/page-header.html.twig', {
-            title: 'hour_report.title'|trans,
+            title: (mode ~ '.title')|trans(),
             type: 'subscribe',
             default_text: 'subscribe_button.subscribe'|trans,
             success_text: 'subscribe_button.unsubscribe'|trans,

--- a/tests/Service/DateTimeHelperTest.php
+++ b/tests/Service/DateTimeHelperTest.php
@@ -197,24 +197,24 @@ class DateTimeHelperTest extends TestCase
         return [
             [
                 'year' => 2024,
-                'expected' => [
+                'expected' => [2024 => [
                     'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
                     'dateTo' => new \DateTime('2024-12-31 23:59:59'),
-                ],
+                ]],
             ],
             [
                 'year' => 2025,
-                'expected' => [
+                'expected' => [2025 => [
                     'dateFrom' => new \DateTime('2025-01-01 00:00:00'),
                     'dateTo' => new \DateTime('2025-12-31 23:59:59'),
-                ],
+                ]],
             ],
             [
                 'year' => 2026,
-                'expected' => [
+                'expected' => [2026 => [
                     'dateFrom' => new \DateTime('2026-01-01 00:00:00'),
                     'dateTo' => new \DateTime('2026-12-31 23:59:59'),
-                ],
+                ]],
             ],
         ];
     }

--- a/tests/Service/DateTimeHelperTest.php
+++ b/tests/Service/DateTimeHelperTest.php
@@ -22,9 +22,9 @@ class DateTimeHelperTest extends TestCase
     /**
      * @dataProvider weekYearProvider
      */
-    public function testGetFirstAndLastDateOfWeek(int $weekNumber, int $year, array $expected): void
+    public function testGetFirstAndLastDatesOfWeeks(array $weekNumbers, int $year, array $expected): void
     {
-        $result = $this->dateTimeHelper->getFirstAndLastDateOfWeek($weekNumber, $year);
+        $result = $this->dateTimeHelper->getFirstAndLastDatesOfWeeks($weekNumbers, $year);
         $this->assertEquals($expected, $result);
     }
 
@@ -32,35 +32,43 @@ class DateTimeHelperTest extends TestCase
     {
         return [
             [
-                'weekNumber' => 1,
+                'weekNumbers' => [1],
                 'year' => 2024,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-                    'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+                    1 => [
+                        'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                        'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'weekNumber' => 52,
+                'weekNumbers' => [52],
                 'year' => 2024,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-12-23 00:00:00'),
-                    'dateTo' => new \DateTime('2024-12-29 23:59:59'),
+                    52 => [
+                        'dateFrom' => new \DateTime('2024-12-23 00:00:00'),
+                        'dateTo' => new \DateTime('2024-12-29 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'weekNumber' => 30,
+                'weekNumbers' => [30],
                 'year' => 2023,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2023-07-24 00:00:00'),
-                    'dateTo' => new \DateTime('2023-07-30 23:59:59'),
+                    30 => [
+                        'dateFrom' => new \DateTime('2023-07-24 00:00:00'),
+                        'dateTo' => new \DateTime('2023-07-30 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'weekNumber' => 1,
+                'weekNumbers' => [1],
                 'year' => 2025,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-12-30 00:00:00'),
-                    'dateTo' => new \DateTime('2025-01-05 23:59:59'),
+                    1 => [
+                        'dateFrom' => new \DateTime('2024-12-30 00:00:00'),
+                        'dateTo' => new \DateTime('2025-01-05 23:59:59'),
+                    ],
                 ],
             ],
         ];
@@ -69,9 +77,9 @@ class DateTimeHelperTest extends TestCase
     /**
      * @dataProvider monthYearProvider
      */
-    public function testGetFirstAndLastDateOfMonth(int $monthNumber, int $year, array $expected): void
+    public function testGetFirstAndLastDatesOfMonths(array $monthNumbers, int $year, array $expected): void
     {
-        $result = $this->dateTimeHelper->getFirstAndLastDateOfMonth($monthNumber, $year);
+        $result = $this->dateTimeHelper->getFirstAndLastDatesOfMonths($monthNumbers, $year);
         $this->assertEquals($expected, $result);
     }
 
@@ -79,35 +87,43 @@ class DateTimeHelperTest extends TestCase
     {
         return [
             [
-                'monthNumber' => 1,
+                'monthNumbers' => [1],
                 'year' => 2024,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-                    'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+                    1 => [
+                        'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                        'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'monthNumber' => 12,
+                'monthNumbers' => [12],
                 'year' => 2024,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-12-01 00:00:00'),
-                    'dateTo' => new \DateTime('2024-12-31 23:59:59'),
+                    12 => [
+                        'dateFrom' => new \DateTime('2024-12-01 00:00:00'),
+                        'dateTo' => new \DateTime('2024-12-31 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'monthNumber' => 2,
+                'monthNumbers' => [2],
                 'year' => 2023,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2023-02-01 00:00:00'),
-                    'dateTo' => new \DateTime('2023-02-28 23:59:59'),
+                    2 => [
+                        'dateFrom' => new \DateTime('2023-02-01 00:00:00'),
+                        'dateTo' => new \DateTime('2023-02-28 23:59:59'),
+                    ],
                 ],
             ],
             [
-                'monthNumber' => 2,
+                'monthNumbers' => [2],
                 'year' => 2024,
                 'expected' => [
-                    'dateFrom' => new \DateTime('2024-02-01 00:00:00'),
-                    'dateTo' => new \DateTime('2024-02-29 23:59:59'),
+                    2 => [
+                        'dateFrom' => new \DateTime('2024-02-01 00:00:00'),
+                        'dateTo' => new \DateTime('2024-02-29 23:59:59'),
+                    ],
                 ],
             ],
         ];

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -57,7 +57,7 @@ class WorkloadReportServiceTest extends TestCase
         $workerRepoMock->method('findAll')->willReturn([$workerMock1, $workerMock2, $workerMock3]);
 
         $worklogRepoMock = $this->createMock(WorklogRepository::class);
-        $worklogRepoMock->method('findWorklogsByWorkerAndDateRange')->willReturn([$worklogMock1]);
+        $worklogRepoMock->method('findWorklogsByDateRange')->willReturn([$worklogMock1]);
 
         $dateTimeHelperMock = $this->createMock(DateTimeHelper::class);
         $dateTimeHelperMock->method('getWeeksOfYear')->willReturn(range(1, 52));
@@ -125,7 +125,7 @@ class WorkloadReportServiceTest extends TestCase
         $workerRepoMock->method('findAll')->willReturn([$workerMock1, $workerMock2, $workerMock3]);
 
         $worklogRepoMock = $this->createMock(WorklogRepository::class);
-        $worklogRepoMock->method('findWorklogsByWorkerAndDateRange')->willReturn([$worklogMock1]);
+        $worklogRepoMock->method('findWorklogsByDateRange')->willReturn([$worklogMock1]);
 
         $dateTimeHelperMock = $this->createMock(DateTimeHelper::class);
         $dateTimeHelperMock->method('getWeeksOfYear')->willReturn(range(1, 52));
@@ -187,7 +187,7 @@ class WorkloadReportServiceTest extends TestCase
         $workerRepoMock->method('findAll')->willReturn([$workerMock1, $workerMock2, $workerMock3]);
 
         $worklogRepoMock = $this->createMock(WorklogRepository::class);
-        $worklogRepoMock->method('findWorklogsByWorkerAndDateRange')->willReturn([$worklogMock1]);
+        $worklogRepoMock->method('findWorklogsByDateRange')->willReturn([$worklogMock1]);
 
         $dateTimeHelperMock = $this->createMock(DateTimeHelper::class);
         $dateTimeHelperMock->method('getWeeksOfYear')->willReturn(range(1, 52));

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -64,14 +64,20 @@ class WorkloadReportServiceTest extends TestCase
         $dateTimeHelperMock->method('getMonthName')->willReturnCallback(function ($month) {
             return date('F', mktime(0, 0, 0, $month, 10));
         });
-        $dateTimeHelperMock->method('getFirstAndLastDateOfWeek')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfWeeks')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+            ],
         ]);
-        $dateTimeHelperMock->method('getFirstAndLastDateOfMonth')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfMonths')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+            ],
         ]);
+
         $dateTimeHelperMock->method('getFirstAndLastDateOfYear')->willReturn([
             'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
             'dateTo' => new \DateTime('2024-12-31 23:59:59'),
@@ -126,14 +132,20 @@ class WorkloadReportServiceTest extends TestCase
         $dateTimeHelperMock->method('getMonthName')->willReturnCallback(function ($month) {
             return date('F', mktime(0, 0, 0, $month, 10));
         });
-        $dateTimeHelperMock->method('getFirstAndLastDateOfWeek')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfWeeks')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+            ],
         ]);
-        $dateTimeHelperMock->method('getFirstAndLastDateOfMonth')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfMonths')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+            ],
         ]);
+
         $dateTimeHelperMock->method('getFirstAndLastDateOfYear')->willReturn([
             'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
             'dateTo' => new \DateTime('2024-12-31 23:59:59'),
@@ -182,14 +194,20 @@ class WorkloadReportServiceTest extends TestCase
         $dateTimeHelperMock->method('getMonthName')->willReturnCallback(function ($month) {
             return date('F', mktime(0, 0, 0, $month, 10));
         });
-        $dateTimeHelperMock->method('getFirstAndLastDateOfWeek')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfWeeks')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-07 23:59:59'),
+            ],
         ]);
-        $dateTimeHelperMock->method('getFirstAndLastDateOfMonth')->willReturn([
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+
+        $dateTimeHelperMock->method('getFirstAndLastDatesOfMonths')->willReturn([
+            1 => [
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-01-31 23:59:59'),
+            ],
         ]);
+
         $dateTimeHelperMock->method('getFirstAndLastDateOfYear')->willReturn([
             'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
             'dateTo' => new \DateTime('2024-12-31 23:59:59'),

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -80,8 +80,10 @@ class WorkloadReportServiceTest extends TestCase
         ]);
 
         $dateTimeHelperMock->method('getFirstAndLastDateOfYear')->willReturn([
+            2024 => [
             'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
             'dateTo' => new \DateTime('2024-12-31 23:59:59'),
+                ]
         ]);
         $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(5);
         $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(23);

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -29,6 +29,7 @@ class WorkloadReportServiceTest extends TestCase
 
     /**
      * @throws Exception
+     * @throws \Exception
      */
     public function testGetWorkloadReport()
     {

--- a/tests/Service/WorkloadReportServiceTest.php
+++ b/tests/Service/WorkloadReportServiceTest.php
@@ -81,9 +81,9 @@ class WorkloadReportServiceTest extends TestCase
 
         $dateTimeHelperMock->method('getFirstAndLastDateOfYear')->willReturn([
             2024 => [
-            'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
-            'dateTo' => new \DateTime('2024-12-31 23:59:59'),
-                ]
+                'dateFrom' => new \DateTime('2024-01-01 00:00:00'),
+                'dateTo' => new \DateTime('2024-12-31 23:59:59'),
+            ],
         ]);
         $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(5);
         $dateTimeHelperMock->method('getWeekdaysBetween')->willReturn(23);


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Improve the loading time of workload report from ~1 minute to ~2 seconds.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
