### PR TITLE
2663: Workload report speed optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-173](https://github.com/itk-dev/economics/pull/173)
+  2663: Workload report loading speed improvement.
 * [PR-167](https://github.com/itk-dev/economics/pull/167)
   2499: Added worker name in workload report.
 * [PR-166](https://github.com/itk-dev/economics/pull/166)

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -437,15 +437,9 @@
         display: none;
     }
     .subscribe-button:before {
+        @apply absolute left-0 w-full text-sm text-right pointer-events-none dark:text-white;
         content: 'Subscribed ' attr(data-frequencies);
-        color: rgb(255 255 255 / var(--tw-text-opacity));
-        position: absolute;
         top: -20px;
-        left: 0;
-        width: 100%;
-        font-size: 14px;
-        text-align: right;
-        pointer-events: none;
     }
     .subscribe-button svg {
         display: inline-block;

--- a/migrations/Version20241008053729.php
+++ b/migrations/Version20241008053729.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241008053729 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX worker_idx ON worklog (worker)');
+        $this->addSql('CREATE INDEX started_idx ON worklog (started)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX worker_idx ON worklog');
+        $this->addSql('DROP INDEX started_idx ON worklog');
+    }
+}

--- a/src/Entity/Worklog.php
+++ b/src/Entity/Worklog.php
@@ -12,6 +12,8 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[ORM\Entity(repositoryClass: WorklogRepository::class)]
 #[ORM\UniqueConstraint(name: 'data_provider_project_tracker', columns: ['data_provider_id', 'worklog_id'])]
 #[UniqueEntity(fields: ['dataProvider', 'worklogId'])]
+#[ORM\Index(fields: ['worker'], name: 'worker_idx')]
+#[ORM\Index(fields: ['started'], name: 'started_idx')]
 class Worklog extends AbstractBaseEntity
 {
     use DataProviderTrait;

--- a/templates/reports/reports.html.twig
+++ b/templates/reports/reports.html.twig
@@ -9,7 +9,7 @@
 
     {% if data is not empty %}
         {{ include('components/page-header.html.twig', {
-            title: 'hour_report.title'|trans,
+            title: (mode ~ '.title')|trans(),
             type: 'subscribe',
             default_text: 'subscribe_button.subscribe'|trans,
             success_text: 'subscribe_button.unsubscribe'|trans,


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/2663

#### Description

Adding two indicies to the worklog table, improving the loading time of workload report from ~1 minute to ~2 seconds.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
