### PR TITLE
hotfix: Correct from/to date check in hourreport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-180](https://github.com/itk-dev/economics/pull/180)
+  hotfix: Corrected from/to date check in hour report.
+
 ## [2.5.0] - 2024-10-23
 
 * [PR-173](https://github.com/itk-dev/economics/pull/173)

--- a/src/Service/HourReportService.php
+++ b/src/Service/HourReportService.php
@@ -93,13 +93,13 @@ class HourReportService
             $timesheetDate = $worklog->getStarted();
 
             if (null !== $fromDate) {
-                if ($timesheetDate <= $fromDate) {
+                if ($timesheetDate < $fromDate) {
                     continue;
                 }
             }
 
             if (null !== $toDate) {
-                if ($timesheetDate >= $toDate) {
+                if ($timesheetDate > $toDate) {
                     continue;
                 }
             }


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

When selecting a fromDate and toDate when configuring an Hour Report, the from and to dates should be included.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
