### PR TITLE
2597-add-epic-migration-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-187](https://github.com/itk-dev/economics/pull/187)
   Updated symfony bundles.
+* [PR-185](https://github.com/itk-dev/economics/pull/186)
+  2597: Added epic migration command.
 * [PR-183](https://github.com/itk-dev/economics/pull/183)
   2597: Added epic relations.
 * [PR-175](https://github.com/itk-dev/economics/pull/175)

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Epic;
+use App\Entity\Issue;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:migrate-epics',
+    description: 'Migrate epics for existing legacy issues, create the epics and add link to join table.',
+)]
+class MigrateEpicsCommand extends Command
+{
+    protected static $defaultName = 'app:assign-epics'; // Default name of the command
+    protected static $defaultDescription = 'Assigns Epics to Issues based on the epicName property.';
+
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $issueRepository = $this->entityManager->getRepository(Issue::class);
+        $epicRepository = $this->entityManager->getRepository(Epic::class);
+
+        // Get all issues
+        $issues = $issueRepository->findAll();
+        if (!$issues) {
+            $output->writeln('<info>No issues found.</info>');
+            return Command::SUCCESS;
+        }
+
+        foreach ($issues as $issue) {
+            // Apply formatting when getting existing epics to avoid duplicates due to letter case.
+            $existingEpics = $issue->getEpics()->map(fn($epic) => trim($epic->getTitle()))->toArray();
+            $epicNameArray = explode(',', $issue->getEpicName());
+            foreach ($epicNameArray as $epicName) {
+                if (empty($epicName)) {
+                    continue;
+                }
+                // Apply formatting to epic names to avoid duplicates due to letter case.
+                $epicName = trim($epicName);
+
+                if (in_array($epicName, $existingEpics, true)) {
+                    continue;
+                }
+
+                // Check if the Epic exists
+                $epic = $epicRepository->findOneBy(['title' => $epicName]);
+
+                if (!$epic) {
+                    // Create a new Epic if it doesn't exist
+                    $epic = new Epic();
+                    $epic->setTitle($epicName);
+
+                    $this->entityManager->persist($epic);
+                    $this->entityManager->flush();
+                    $output->writeln('<info>Created new Epic: ' . $epicName . '</info>');
+                }
+
+                // Assign the Epic to the Issue
+                $issue->addEpic($epic);
+
+                $this->entityManager->persist($issue);
+                $output->writeln('<comment>Assigned Epic "' . $epicName . '" to Issue #' . $issue->getId() . '</comment>');
+            }
+        }
+
+        // Save changes to the database
+        $this->entityManager->flush();
+
+        $output->writeln('<info>All issues have been processed successfully.</info>');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:migrate-epics',
@@ -61,6 +62,8 @@ class MigrateEpicsCommand extends Command
                     // Create a new Epic if it doesn't exist
                     $epic = new Epic();
                     $epic->setTitle($epicName);
+                    $this->entityManager->persist($epic);
+                    $this->entityManager->flush();
                     $io->success('Created new Epic: ' . $epicName);
                 }
 

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -31,11 +31,12 @@ class MigrateEpicsCommand extends Command
     {
         $issueRepository = $this->entityManager->getRepository(Issue::class);
         $epicRepository = $this->entityManager->getRepository(Epic::class);
+        $io = new SymfonyStyle($input, $output);
 
         // Get all issues
         $issues = $issueRepository->findAll();
-        if (empty($issues)) {
-            $output->writeln('<info>No issues found.</info>');
+        if (!$issues) {
+            $io->info('No issues found.');
 
             return Command::SUCCESS;
         }
@@ -60,24 +61,21 @@ class MigrateEpicsCommand extends Command
                     // Create a new Epic if it doesn't exist
                     $epic = new Epic();
                     $epic->setTitle($epicName);
-
-                    $this->entityManager->persist($epic);
-                    $this->entityManager->flush();
-                    $output->writeln('<info>Created new Epic: '.$epicName.'</info>');
+                    $io->success('Created new Epic: ' . $epicName);
                 }
 
                 // Assign the Epic to the Issue
                 $issue->addEpic($epic);
 
                 $this->entityManager->persist($issue);
-                $output->writeln('<comment>Assigned Epic "'.$epicName.'" to Issue #'.$issue->getId().'</comment>');
+                $io->comment('Assigned Epic "' . $epicName . '" to Issue #' . $issue->getId());
             }
         }
 
         // Save changes to the database
         $this->entityManager->flush();
 
-        $output->writeln('<info>All issues have been processed successfully.</info>');
+        $io->success('All issues have been processed successfully.');
 
         return Command::SUCCESS;
     }

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -41,14 +41,12 @@ class MigrateEpicsCommand extends Command
         }
 
         foreach ($issues as $issue) {
-            // Apply formatting when getting existing epics to avoid duplicates due to letter case.
             $existingEpics = $issue->getEpics()->map(fn ($epic) => trim($epic->getTitle() ?? ''))->toArray();
             $epicNameArray = explode(',', $issue->getEpicName() ?? '');
             foreach ($epicNameArray as $epicName) {
                 if (empty($epicName)) {
                     continue;
                 }
-                // Apply formatting to epic names to avoid duplicates due to letter case.
                 $epicName = trim($epicName);
 
                 if (in_array($epicName, $existingEpics, true)) {

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -2,10 +2,7 @@
 
 namespace App\Command;
 
-use App\Entity\Epic;
-use App\Entity\Issue;
 use App\Service\DataSynchronizationService;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,8 +17,7 @@ class MigrateEpicsCommand extends Command
 {
     public function __construct(
         private DataSynchronizationService $dataSynchronizationService,
-    )
-    {
+    ) {
         parent::__construct();
     }
 

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -4,6 +4,7 @@ namespace App\Command;
 
 use App\Entity\Epic;
 use App\Entity\Issue;
+use App\Service\DataSynchronizationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -17,66 +18,26 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class MigrateEpicsCommand extends Command
 {
-    protected static $defaultName = 'app:assign-epics'; // Default name of the command
-    protected static $defaultDescription = 'Assigns Epics to Issues based on the epicName property.';
-
-    private EntityManagerInterface $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(
+        private DataSynchronizationService $dataSynchronizationService,
+    )
     {
         parent::__construct();
-        $this->entityManager = $entityManager;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $issueRepository = $this->entityManager->getRepository(Issue::class);
-        $epicRepository = $this->entityManager->getRepository(Epic::class);
         $io = new SymfonyStyle($input, $output);
 
-        // Get all issues
-        $issues = $issueRepository->findAll();
-        if (!$issues) {
-            $io->info('No issues found.');
-
-            return Command::SUCCESS;
-        }
-
-        foreach ($issues as $issue) {
-            $existingEpics = $issue->getEpics()->map(fn ($epic) => trim($epic->getTitle() ?? ''))->toArray();
-            $epicNameArray = explode(',', $issue->getEpicName() ?? '');
-            foreach ($epicNameArray as $epicName) {
-                if (empty($epicName)) {
-                    continue;
-                }
-                $epicName = trim($epicName);
-
-                if (in_array($epicName, $existingEpics, true)) {
-                    continue;
-                }
-
-                // Check if the Epic exists
-                $epic = $epicRepository->findOneBy(['title' => $epicName]);
-
-                if (!$epic) {
-                    // Create a new Epic if it doesn't exist
-                    $epic = new Epic();
-                    $epic->setTitle($epicName);
-                    $this->entityManager->persist($epic);
-                    $this->entityManager->flush();
-                    $io->success('Created new Epic: ' . $epicName);
-                }
-
-                // Assign the Epic to the Issue
-                $issue->addEpic($epic);
-
-                $this->entityManager->persist($issue);
-                $io->comment('Assigned Epic "' . $epicName . '" to Issue #' . $issue->getId());
+        $this->dataSynchronizationService->migrateEpics(function ($i, $length) use ($io) {
+            if (0 == $i) {
+                $io->progressStart($length);
+            } elseif ($i >= $length - 1) {
+                $io->progressFinish();
+            } else {
+                $io->progressAdvance();
             }
-        }
-
-        // Save changes to the database
-        $this->entityManager->flush();
+        });
 
         $io->success('All issues have been processed successfully.');
 

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -34,7 +34,7 @@ class MigrateEpicsCommand extends Command
 
         // Get all issues
         $issues = $issueRepository->findAll();
-        if (!$issues) {
+        if (empty($issues)) {
             $output->writeln('<info>No issues found.</info>');
 
             return Command::SUCCESS;

--- a/src/Command/MigrateEpicsCommand.php
+++ b/src/Command/MigrateEpicsCommand.php
@@ -36,13 +36,14 @@ class MigrateEpicsCommand extends Command
         $issues = $issueRepository->findAll();
         if (!$issues) {
             $output->writeln('<info>No issues found.</info>');
+
             return Command::SUCCESS;
         }
 
         foreach ($issues as $issue) {
             // Apply formatting when getting existing epics to avoid duplicates due to letter case.
-            $existingEpics = $issue->getEpics()->map(fn($epic) => trim($epic->getTitle()))->toArray();
-            $epicNameArray = explode(',', $issue->getEpicName());
+            $existingEpics = $issue->getEpics()->map(fn ($epic) => trim($epic->getTitle() ?? ''))->toArray();
+            $epicNameArray = explode(',', $issue->getEpicName() ?? '');
             foreach ($epicNameArray as $epicName) {
                 if (empty($epicName)) {
                     continue;
@@ -64,14 +65,14 @@ class MigrateEpicsCommand extends Command
 
                     $this->entityManager->persist($epic);
                     $this->entityManager->flush();
-                    $output->writeln('<info>Created new Epic: ' . $epicName . '</info>');
+                    $output->writeln('<info>Created new Epic: '.$epicName.'</info>');
                 }
 
                 // Assign the Epic to the Issue
                 $issue->addEpic($epic);
 
                 $this->entityManager->persist($issue);
-                $output->writeln('<comment>Assigned Epic "' . $epicName . '" to Issue #' . $issue->getId() . '</comment>');
+                $output->writeln('<comment>Assigned Epic "'.$epicName.'" to Issue #'.$issue->getId().'</comment>');
             }
         }
 
@@ -79,6 +80,7 @@ class MigrateEpicsCommand extends Command
         $this->entityManager->flush();
 
         $output->writeln('<info>All issues have been processed successfully.</info>');
+
         return Command::SUCCESS;
     }
 }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures;
 
 use App\Entity\Client;
 use App\Entity\DataProvider;
+use App\Entity\Epic;
 use App\Entity\Issue;
 use App\Entity\Project;
 use App\Entity\Version;
@@ -50,6 +51,10 @@ class AppFixtures extends Fixture
             $manager->persist($worker);
             $workerArray[] = 'test'.$i.'@test';
         }
+
+        $epic = new Epic();
+        $epic->setTitle("Epic 1");
+        $manager->persist($epic);
 
         foreach ($dataProviders as $key => $dataProvider) {
             $manager->persist($dataProvider);
@@ -113,8 +118,8 @@ class AppFixtures extends Fixture
                     $issue->setProjectTrackerId("issue-$i-$j");
                     $issue->setAccountId('Account 1');
                     $issue->setAccountKey('Account 1');
-                    $issue->setEpicName('Epic 1');
-                    $issue->setEpicKey('Epic 1');
+                    $issue->setEpicName('Epic ' . $j % 2 . ($j % 5 == 0 ? ",More than one Epic" : ''));
+                    $issue->setEpicKey('Epic ' . $j % 2);
                     $issue->setStatus($modStatus);
                     $issue->setDataProvider($dataProvider);
                     $issue->addVersion($versions[$j % count($versions)]);
@@ -125,8 +130,11 @@ class AppFixtures extends Fixture
                     $issue->setDueDate(new \DateTime());
                     $issue->setWorker($workerArray[rand(0, 9)]);
                     $issue->setLinkToIssue('www.example.com');
-
                     $manager->persist($issue);
+
+                    if ($key == 0 && $i == 0 && $j == 0) {
+                        $issue->addEpic($epic);
+                    }
 
                     for ($k = 0; $k < 100; ++$k) {
                         $year = (new \DateTime())->format('Y');

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -118,8 +118,8 @@ class AppFixtures extends Fixture
                     $issue->setProjectTrackerId("issue-$i-$j");
                     $issue->setAccountId('Account 1');
                     $issue->setAccountKey('Account 1');
-                    $issue->setEpicName('Epic '.$j % 2 .(0 == $j % 5 ? ',More than one Epic' : ''));
-                    $issue->setEpicKey('Epic '.$j % 2);
+                    $issue->setEpicName('Epic '.$j % 2 .(1 == $key && 0 == $j % 5 ? ',More than one Epic' : ''));
+                    $issue->setEpicKey('Epic '.$j % 2 .(1 == $key && 0 == $j % 5 ? ',More than one Epic' : ''));
                     $issue->setStatus($modStatus);
                     $issue->setDataProvider($dataProvider);
                     $issue->addVersion($versions[$j % count($versions)]);

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -53,7 +53,7 @@ class AppFixtures extends Fixture
         }
 
         $epic = new Epic();
-        $epic->setTitle("Epic 1");
+        $epic->setTitle('Epic 1');
         $manager->persist($epic);
 
         foreach ($dataProviders as $key => $dataProvider) {
@@ -118,8 +118,8 @@ class AppFixtures extends Fixture
                     $issue->setProjectTrackerId("issue-$i-$j");
                     $issue->setAccountId('Account 1');
                     $issue->setAccountKey('Account 1');
-                    $issue->setEpicName('Epic ' . $j % 2 . ($j % 5 == 0 ? ",More than one Epic" : ''));
-                    $issue->setEpicKey('Epic ' . $j % 2);
+                    $issue->setEpicName('Epic '.$j % 2 .(0 == $j % 5 ? ',More than one Epic' : ''));
+                    $issue->setEpicKey('Epic '.$j % 2);
                     $issue->setStatus($modStatus);
                     $issue->setDataProvider($dataProvider);
                     $issue->addVersion($versions[$j % count($versions)]);
@@ -132,7 +132,7 @@ class AppFixtures extends Fixture
                     $issue->setLinkToIssue('www.example.com');
                     $manager->persist($issue);
 
-                    if ($key == 0 && $i == 0 && $j == 0) {
+                    if (0 == $key && 0 == $i && 0 == $j) {
                         $issue->addEpic($epic);
                     }
 

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -483,6 +483,7 @@ class DataSynchronizationService
      * Migrate from issue.epicName to issue.epics.
      *
      * @param callable|null $progressCallback
+     *
      * @return void
      */
     public function migrateEpics(?callable $progressCallback = null): void
@@ -499,11 +500,12 @@ class DataSynchronizationService
         $issuesProcessed = 0;
 
         foreach ($issues as $issue) {
-            $existingEpicNames = $issue->getEpics()->reduce(function(array $carry, Epic $epic) {
+            $existingEpicNames = $issue->getEpics()->reduce(function (array $carry, Epic $epic) {
                 $epicName = $epic->getTitle();
-                if ($epicName !== null && !in_array($epicName, $carry)) {
+                if (null !== $epicName && !in_array($epicName, $carry)) {
                     $carry[] = $epic->getTitle();
                 }
+
                 return $carry;
             }, []);
 
@@ -522,7 +524,7 @@ class DataSynchronizationService
 
                 $epic = $this->epicRepository->findOneBy(['title' => $epicName]);
 
-                if ($epic == null) {
+                if (null == $epic) {
                     // Create a new Epic if it doesn't exist
                     $epic = new Epic();
                     $epic->setTitle($epicName);
@@ -535,7 +537,7 @@ class DataSynchronizationService
 
             if (null !== $progressCallback) {
                 $progressCallback($issuesProcessed, count($issues));
-                $issuesProcessed++;
+                ++$issuesProcessed;
             }
         }
 

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -509,14 +509,20 @@ class DataSynchronizationService
                 return $carry;
             }, []);
 
-            $epicNameArray = explode(',', $issue->getEpicName() ?? '');
+            $epicNameArray = [];
+
+            if (LeantimeApiService::class === $issue->getDataProvider()?->getClass()) {
+                $epicNameArray = explode(',', $issue->getEpicName() ?? '');
+            } elseif (!empty($issue->getEpicName())) {
+                $epicNameArray[] = $issue->getEpicName();
+            }
 
             foreach ($epicNameArray as $epicName) {
-                $epicName = trim($epicName);
-
                 if (empty($epicName)) {
                     continue;
                 }
+
+                $epicName = trim($epicName);
 
                 if (in_array($epicName, $existingEpicNames, true)) {
                     continue;

--- a/tests/Service/DataSynchronizationServiceTest.php
+++ b/tests/Service/DataSynchronizationServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Repository\EpicRepository;
+use App\Service\DataSynchronizationService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DataSynchronizationServiceTest extends KernelTestCase
+{
+    public function testGetIssuesNotIncludedInProjectBilling(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $epicRepository = $container->get(EpicRepository::class);
+
+        $this->assertCount(1, $epicRepository->findAll());
+
+        $dataSynchronizationService = $container->get(DataSynchronizationService::class);
+
+        $dataSynchronizationService->migrateEpics();
+
+        $this->assertCount(3, $epicRepository->findAll());
+    }
+}


### PR DESCRIPTION
#### Link to ticket

[#2597](https://leantime.itkdev.dk/#/tickets/showTicket/2597)

#### Description

Adds a command for migrating epics of existing/legacy issues to new entities. 
Should be fired once when the new changes are released in production.

#### Screenshot of the result

N/A

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
