### PR TITLE
Feature: Billable unbilled hours missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-213](https://github.com/itk-dev/economics/pull/213)
+  Include isBilled = NULL in billable unbilled hours report.
+
 ## [2.8.3] - 2025-03-26
 
 * [PR-212](https://github.com/itk-dev/economics/pull/212)

--- a/src/Repository/WorklogRepository.php
+++ b/src/Repository/WorklogRepository.php
@@ -170,7 +170,6 @@ class WorklogRepository extends ServiceEntityRepository
     {
         $nonBillableEpics = NonBillableEpicsEnum::getAsArray();
         $nonBillableVersions = NonBillableVersionsEnum::getAsArray();
-
         $qb = $this->createQueryBuilder('worklog');
 
         $qb->leftJoin(Project::class, 'project', 'WITH', 'project.id = worklog.project')
@@ -192,7 +191,10 @@ class WorklogRepository extends ServiceEntityRepository
             ));
 
         if (null !== $isBilled) {
-            $qb->andWhere($qb->expr()->eq('worklog.isBilled', ':isBilled'));
+            $qb->andWhere($qb->expr()->orX(
+                $qb->expr()->eq('worklog.isBilled', ':isBilled'),
+                $qb->expr()->isNull('worklog.isBilled')
+            ));
         }
 
         if (null !== $workerIdentifier) {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3602

#### Description

Normally, unbilled worklogs should have isBilled set to false. Probably due to how values are set when logging time though Leantime Timetable, isBilled is unset and therefore evaluates to NULL when worklogs are synced.

Therefore, we need to include 'isBilled = NULL' in the query.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
