### PR TITLE
3602: Explicitly define isBilled on worklogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-214](https://github.com/itk-dev/economics/pull/214)
+  Explicitly set isBilled when synchronizing worklogs.
+
 ## [2.8.3] - 2025-03-26
 
 * [PR-212](https://github.com/itk-dev/economics/pull/212)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-214](https://github.com/itk-dev/economics/pull/214)
   Explicitly set isBilled when synchronizing worklogs.
+  Select isBilled=NULL when getting unbilled billable worklogs.
 
 ## [2.8.3] - 2025-03-26
 

--- a/src/Repository/WorklogRepository.php
+++ b/src/Repository/WorklogRepository.php
@@ -192,7 +192,15 @@ class WorklogRepository extends ServiceEntityRepository
             ));
 
         if (null !== $isBilled) {
-            $qb->andWhere($qb->expr()->eq('worklog.isBilled', ':isBilled'));
+            if ($isBilled) {
+                $qb->andWhere($qb->expr()->eq('worklog.isBilled', true));
+            } else {
+                // We treat null as false.
+                $qb->andWhere($qb->expr()->orX(
+                    $qb->expr()->eq('worklog.isBilled', false),
+                    $qb->expr()->isNull('worklog.isBilled')
+                ));
+            }
         }
 
         if (null !== $workerIdentifier) {

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -400,10 +400,8 @@ class DataSynchronizationService
                 $issue = $this->issueRepository->findOneBy(['projectTrackerId' => $worklog->getProjectTrackerIssueId()]);
                 $worklog->setIssue($issue);
             }
-            if (!$worklog->isBilled() && $worklogDatum->projectTrackerIsBilled) {
-                $worklog->setIsBilled(true);
-                $worklog->setBilledSeconds($worklogDatum->timeSpentSeconds);
-            } else {
+
+            if ($worklog->isBilled() === null) {
                 $worklog->setIsBilled(false);
             }
 

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -401,7 +401,7 @@ class DataSynchronizationService
                 $worklog->setIssue($issue);
             }
 
-            if ($worklog->isBilled() === null) {
+            if (null === $worklog->isBilled()) {
                 $worklog->setIsBilled(false);
             }
 

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -400,10 +400,11 @@ class DataSynchronizationService
                 $issue = $this->issueRepository->findOneBy(['projectTrackerId' => $worklog->getProjectTrackerIssueId()]);
                 $worklog->setIssue($issue);
             }
-
             if (!$worklog->isBilled() && $worklogDatum->projectTrackerIsBilled) {
                 $worklog->setIsBilled(true);
                 $worklog->setBilledSeconds($worklogDatum->timeSpentSeconds);
+            } else {
+                $worklog->setIsBilled(false);
             }
 
             $project->addWorklog($worklog);


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3602

#### Description

Normally, unbilled worklogs should have isBilled set to false. Probably due to how values are set when logging time though Leantime Timetable, isBilled is unset and therefore evaluates to NULL when worklogs are synced.

Therefore, we need to explicitly set isBilled to 0 during sync.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
