### PR TITLE
Optimize app:sync command, fix issues with wrong usage of entitymanager->clear(), limit redundant db queries

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -74,3 +74,7 @@ services:
     App\MessageHandler\SynchronizeHandler:
         arguments:
             $monitoringUrl: '%env(string:SYNC_MONITORING_URL)%'
+
+    App\Command\SyncCommand:
+        arguments:
+            $monitoringUrl: '%env(string:SYNC_MONITORING_URL)%'

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -2,16 +2,24 @@
 
 namespace App\Command;
 
+use App\Entity\Project;
+use App\Entity\SynchronizationJob;
+use App\Enum\SynchronizationStatusEnum;
+use App\Enum\SynchronizationStepEnum;
 use App\Exception\EconomicsException;
 use App\Exception\UnsupportedDataProviderException;
 use App\Repository\DataProviderRepository;
 use App\Repository\ProjectRepository;
+use App\Repository\SynchronizationJobRepository;
 use App\Service\DataSynchronizationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsCommand(
     name: 'app:sync',
@@ -23,6 +31,11 @@ class SyncCommand extends Command
         private readonly ProjectRepository $projectRepository,
         private readonly DataProviderRepository $dataProviderRepository,
         private readonly DataSynchronizationService $dataSynchronizationService,
+        private readonly SynchronizationJobRepository $synchronizationJobRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HttpClientInterface $client,
+        private readonly LoggerInterface $logger,
+        private readonly string $monitoringUrl,
     ) {
         parent::__construct($this->getName());
     }
@@ -39,37 +52,38 @@ class SyncCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $io->info('Processing projects');
-
         $dataProviders = $this->dataProviderRepository->findBy(['enabled' => true]);
 
+        $job = new SynchronizationJob();
+        $job->setStarted(new \DateTime());
+        $job->addMessage('Synchronization started');
+        $job->setProgress(0);
+        $job->setStatus(SynchronizationStatusEnum::RUNNING);
+        $this->synchronizationJobRepository->save($job, true);
+
+        $io->info('Processing projects');
+        $job->setStep(SynchronizationStepEnum::PROJECTS);
+
+        $this->entityManager->flush();
+
         foreach ($dataProviders as $dataProvider) {
-            $this->dataSynchronizationService->syncProjects(function ($i, $length) use ($io) {
-                if (0 == $i) {
-                    $io->progressStart($length);
-                } elseif ($i >= $length - 1) {
-                    $io->progressFinish();
-                } else {
-                    $io->progressAdvance();
-                }
+            $job->addMessage('Processing projects from '.$dataProvider->getName());
+            $this->dataSynchronizationService->syncProjects(function ($i, $length) use ($io, $job) {
+                $this->setProgress($i, $length, $io, $job);
             }, $dataProvider);
         }
 
         $io->info('Processing accounts');
+        $this->setStep(SynchronizationStepEnum::ACCOUNTS, $job);
 
         foreach ($dataProviders as $dataProvider) {
-            $this->dataSynchronizationService->syncAccounts(function ($i, $length) use ($io) {
-                if (0 == $i) {
-                    $io->progressStart($length);
-                } elseif ($i >= $length - 1) {
-                    $io->progressFinish();
-                } else {
-                    $io->progressAdvance();
-                }
+            $this->dataSynchronizationService->syncAccounts(function ($i, $length) use ($io, $job) {
+                $this->setProgress($i, $length, $io, $job);
             }, $dataProvider);
         }
 
         $io->info('Processing issues');
+        $this->setStep(SynchronizationStepEnum::ISSUES, $job);
 
         foreach ($dataProviders as $dataProvider) {
             $projects = $this->projectRepository->findBy(['include' => true, 'dataProvider' => $dataProvider]);
@@ -77,14 +91,8 @@ class SyncCommand extends Command
             foreach ($projects as $project) {
                 $io->writeln("Processing issues for {$project->getName()}");
 
-                $this->dataSynchronizationService->syncIssuesForProject($project->getId(), $dataProvider, function ($i, $length) use ($io) {
-                    if (0 == $i) {
-                        $io->progressStart($length);
-                    } elseif ($i >= $length - 1) {
-                        $io->progressFinish();
-                    } else {
-                        $io->progressAdvance();
-                    }
+                $this->dataSynchronizationService->syncIssuesForProject($project->getId(), $dataProvider, function ($i, $length) use ($io, $job) {
+                    $this->setProgress($i, $length, $io, $job);
                 });
 
                 $io->writeln('');
@@ -92,27 +100,81 @@ class SyncCommand extends Command
         }
 
         $io->info('Processing worklogs');
+        $this->setStep(SynchronizationStepEnum::WORKLOGS, $job);
 
         foreach ($dataProviders as $dataProvider) {
             $projects = $this->projectRepository->findBy(['include' => true, 'dataProvider' => $dataProvider]);
 
+            /** @var Project $project */
             foreach ($projects as $project) {
                 $io->writeln("Processing worklogs for {$project->getName()}");
 
-                $this->dataSynchronizationService->syncWorklogsForProject($project->getId(), $dataProvider, function ($i, $length) use ($io) {
-                    if (0 == $i) {
-                        $io->progressStart($length);
-                    } elseif ($i >= $length - 1) {
-                        $io->progressFinish();
-                    } else {
-                        $io->progressAdvance();
-                    }
+                $projectId = $project->getId();
+
+                if (null === $projectId) {
+                    throw new \RuntimeException('Project id is null');
+                }
+
+                $this->dataSynchronizationService->syncWorklogsForProject($projectId, $dataProvider, function ($i, $length) use ($io, $job) {
+                    $this->setProgress($i, $length, $io, $job);
                 });
 
                 $io->writeln('');
             }
         }
 
+        $job = $this->getJob($job);
+        $job->setStatus(SynchronizationStatusEnum::DONE);
+        $job->setEnded(new \DateTime());
+        $this->entityManager->flush();
+
+        // Call monitoring url if defined.
+        if ('' !== $this->monitoringUrl) {
+            try {
+                $this->client->request('GET', $this->monitoringUrl);
+            } catch (\Throwable $e) {
+                $this->logger->error('Error calling monitoringUrl: '.$e->getMessage());
+            }
+        }
+
         return Command::SUCCESS;
+    }
+
+    private function setProgress(int $i, int $length, SymfonyStyle $io, SynchronizationJob $job): void
+    {
+        $job = $this->getJob($job);
+
+        if (0 == $i) {
+            $io->progressStart($length);
+            $job->setProgress($i);
+        } elseif ($i >= $length - 1) {
+            $io->progressFinish();
+            $job->setProgress(100);
+        } else {
+            $length = 0 < $length ? $length : 1;
+            $io->progressAdvance();
+            $job->setProgress(intdiv($i * 100, $length));
+        }
+    }
+
+    private function setStep(SynchronizationStepEnum $step, SynchronizationJob $job): void
+    {
+        $job = $this->getJob($job);
+
+        $job->setStep($step);
+        $this->entityManager->flush();
+    }
+
+    private function getJob(SynchronizationJob $job): SynchronizationJob
+    {
+        if (!$this->entityManager->contains($job)) {
+            $job = $this->synchronizationJobRepository->find($job->getId());
+
+            if (null === $job) {
+                throw new \RuntimeException('Job not found');
+            }
+        }
+
+        return $job;
     }
 }

--- a/src/Controller/SynchronizationJobController.php
+++ b/src/Controller/SynchronizationJobController.php
@@ -6,6 +6,7 @@ use App\Entity\SynchronizationJob;
 use App\Enum\SynchronizationStatusEnum;
 use App\Message\SynchronizeMessage;
 use App\Repository\SynchronizationJobRepository;
+use HttpResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,26 +45,29 @@ class SynchronizationJobController extends AbstractController
     #[IsGranted('ROLE_ADMIN')]
     public function sync(SynchronizationJobRepository $synchronizationJobRepository, MessageBusInterface $bus): Response
     {
-        $latestJob = $synchronizationJobRepository->getLatestJob();
+        return new JsonResponse([], Response::HTTP_SERVICE_UNAVAILABLE);
 
-        if (null !== $latestJob && in_array($latestJob->getStatus(), [SynchronizationStatusEnum::NOT_STARTED, SynchronizationStatusEnum::RUNNING])) {
-            return new JsonResponse(['message' => 'existing job'], Response::HTTP_CONFLICT);
-        }
-
-        $job = new SynchronizationJob();
-        $job->setStatus(SynchronizationStatusEnum::NOT_STARTED);
-        $synchronizationJobRepository->save($job, true);
-
-        $jobId = $job->getId();
-
-        if (null === $jobId) {
-            throw new \Exception('Job id not found');
-        }
-
-        $message = new SynchronizeMessage($jobId);
-
-        $bus->dispatch($message);
-
-        return new JsonResponse([], 200);
+//        @TODO re-enable when sync is fully re-factored
+//        $latestJob = $synchronizationJobRepository->getLatestJob();
+//
+//        if (null !== $latestJob && in_array($latestJob->getStatus(), [SynchronizationStatusEnum::NOT_STARTED, SynchronizationStatusEnum::RUNNING])) {
+//            return new JsonResponse(['message' => 'existing job'], Response::HTTP_CONFLICT);
+//        }
+//
+//        $job = new SynchronizationJob();
+//        $job->setStatus(SynchronizationStatusEnum::NOT_STARTED);
+//        $synchronizationJobRepository->save($job, true);
+//
+//        $jobId = $job->getId();
+//
+//        if (null === $jobId) {
+//            throw new \Exception('Job id not found');
+//        }
+//
+//        $message = new SynchronizeMessage($jobId);
+//
+//        $bus->dispatch($message);
+//
+//        return new JsonResponse([], 200);
     }
 }

--- a/src/Entity/SynchronizationJob.php
+++ b/src/Entity/SynchronizationJob.php
@@ -100,4 +100,11 @@ class SynchronizationJob extends AbstractBaseEntity
 
         return $this;
     }
+
+    public function addMessage(string $message): static
+    {
+        $this->messages .= $message."\n";
+
+        return $this;
+    }
 }

--- a/src/Service/DataSynchronizationService.php
+++ b/src/Service/DataSynchronizationService.php
@@ -32,8 +32,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DataSynchronizationService
 {
-    private const BATCH_SIZE = 200;
-    private const MAX_RESULTS = 50;
+    private const int BATCH_SIZE = 200;
+    private const int MAX_RESULTS = 50;
+
+    private array $issues = [];
+    private array $workers = [];
+    private array $versions = [];
+    private array $epics = [];
 
     public function __construct(
         private readonly ProjectRepository $projectRepository,
@@ -60,8 +65,6 @@ class DataSynchronizationService
      */
     public function syncProjects(callable $progressCallback, DataProvider $dataProvider): void
     {
-        $dataProviderId = $dataProvider->getId();
-
         $service = $this->dataProviderService->getService($dataProvider);
 
         // Get all projects from ApiService.
@@ -71,7 +74,7 @@ class DataSynchronizationService
                 'projectTrackerId' => $projectDatum->projectTrackerId,
                 'dataProvider' => $dataProvider,
             ]);
-            $dataProvider = $this->dataProviderRepository->find($dataProviderId);
+            $dataProvider = $this->getDataProvider($dataProvider);
 
             if (!$project) {
                 $project = new Project();
@@ -87,10 +90,7 @@ class DataSynchronizationService
             foreach ($projectDatum->versions as $versions) {
                 /** @var VersionModel $versionDatum */
                 foreach ($versions as $versionDatum) {
-                    $version = $this->versionRepository->findOneBy([
-                        'projectTrackerId' => $versionDatum->id,
-                        'dataProvider' => $dataProvider,
-                    ]);
+                    $version = $this->getVersion($versionDatum->id, $dataProvider);
 
                     if (!$version) {
                         $version = new Version();
@@ -105,7 +105,7 @@ class DataSynchronizationService
             }
 
             // Only synchronize clients if this is enabled.
-            if (null != $dataProvider && $dataProvider->isEnableClientSync()) {
+            if ($dataProvider->isEnableClientSync()) {
                 $projectClientData = $service->getClientDataForProject($projectDatum->projectTrackerId);
 
                 foreach ($projectClientData as $clientData) {
@@ -138,14 +138,14 @@ class DataSynchronizationService
             // Flush and clear for each batch.
             if (0 === intval($index) % self::BATCH_SIZE) {
                 $this->entityManager->flush();
-                $this->entityManager->clear();
+                $this->clear();
             }
 
             $progressCallback($index, count($allProjectData->projectData));
         }
 
         $this->entityManager->flush();
-        $this->entityManager->clear();
+        $this->clear();
     }
 
     /**
@@ -184,14 +184,14 @@ class DataSynchronizationService
                 // Flush and clear for each batch.
                 if (0 === intval($index) % self::BATCH_SIZE) {
                     $this->entityManager->flush();
-                    $this->entityManager->clear();
+                    $this->clear();
                 }
 
                 $progressCallback($index, count($allAccountData));
             }
 
             $this->entityManager->flush();
-            $this->entityManager->clear();
+            $this->clear();
         }
     }
 
@@ -203,8 +203,6 @@ class DataSynchronizationService
      */
     public function syncIssuesForProject(int $projectId, DataProvider $dataProvider, ?callable $progressCallback = null): void
     {
-        $dataProviderId = $dataProvider->getId();
-
         $service = $this->dataProviderService->getService($dataProvider);
 
         $project = $this->projectRepository->find($projectId);
@@ -223,20 +221,15 @@ class DataSynchronizationService
 
         $startAt = 0;
         do {
-            $dataProvider = $this->dataProviderRepository->find($dataProviderId);
-            $project = $this->projectRepository->find($projectId);
-            if (!$project) {
-                throw new EconomicsException($this->translator->trans('exception.project_not_found'));
-            }
+            $dataProvider = $this->getDataProvider($dataProvider);
+            $project = $this->getProject($project);
 
             $pagedIssueData = $service->getIssuesDataForProjectPaged($projectTrackerId, $startAt, self::MAX_RESULTS);
             $total = $pagedIssueData->total;
 
             foreach ($pagedIssueData->items as $issueDatum) {
-                $issue = $this->issueRepository->findOneBy([
-                    'projectTrackerId' => $issueDatum->projectTrackerId,
-                    'dataProvider' => $dataProvider,
-                ]);
+                $dataProvider = $this->getDataProvider($dataProvider);
+                $issue = $this->getIssue($issueDatum->projectTrackerId, $dataProvider);
 
                 if (!$issue) {
                     $issue = new Issue();
@@ -265,15 +258,12 @@ class DataSynchronizationService
                 $issue->setLinkToIssue($issueDatum->linkToIssue);
 
                 // Leantime (as of now) supports only a single version (milestone) per issue.
-                if (LeantimeApiService::class === $dataProvider?->getClass()) {
+                if (LeantimeApiService::class === $dataProvider->getClass()) {
                     $issue->getVersions()->clear();
                 }
 
                 foreach ($issueDatum->versions as $versionData) {
-                    $version = $this->versionRepository->findOneBy([
-                        'projectTrackerId' => $versionData->projectTrackerId,
-                        'dataProvider' => $dataProvider,
-                    ]);
+                    $version = $this->getVersion($versionData->projectTrackerId, $dataProvider);
 
                     if (null !== $version) {
                         $issue->addVersion($version);
@@ -284,13 +274,12 @@ class DataSynchronizationService
                     if (empty($epicTitle)) {
                         continue;
                     }
-                    $epic = $this->epicRepository->findOneBy(['title' => $epicTitle]);
+                    $epic = $this->getEpic($epicTitle);
 
                     if (null === $epic) {
                         $epic = new Epic();
                         $epic->setTitle($epicTitle);
                         $this->entityManager->persist($epic);
-                        $this->entityManager->flush();
                     }
 
                     $issue->addEpic($epic);
@@ -305,11 +294,11 @@ class DataSynchronizationService
             $startAt += $pagedIssueData->maxResults;
 
             $this->entityManager->flush();
-            $this->entityManager->clear();
+            $this->clear();
         } while ($startAt < $total);
 
         $this->entityManager->flush();
-        $this->entityManager->clear();
+        $this->clear();
     }
 
     /**
@@ -320,8 +309,6 @@ class DataSynchronizationService
      */
     public function syncWorklogsForProject(int $projectId, DataProvider $dataProvider, ?callable $progressCallback = null): void
     {
-        $dataProviderId = $dataProvider->getId();
-
         $service = $this->dataProviderService->getService($dataProvider);
 
         $project = $this->projectRepository->find($projectId);
@@ -359,17 +346,11 @@ class DataSynchronizationService
 
         $worklogData = $service->getWorklogDataCollection($projectTrackerId);
         $worklogsAdded = 0;
+        $worklogsCount = count($worklogData->worklogData);
         foreach ($worklogData->worklogData as $worklogDatum) {
-            $project = $this->projectRepository->find($projectId);
+            $project = $this->getProject($project);
 
-            if (!$project) {
-                throw new EconomicsException($this->translator->trans('exception.project_not_found'));
-            }
-
-            $issue = !empty($worklogDatum->projectTrackerIssueId) ? $this->issueRepository->findOneBy([
-                'projectTrackerId' => $worklogDatum->projectTrackerIssueId,
-                'dataProvider' => $dataProvider,
-            ]) : null;
+            $issue = $this->getIssue($worklogDatum->projectTrackerIssueId, $dataProvider);
 
             if (null === $issue) {
                 // A worklog should always have an issue, so ignore the worklog.
@@ -383,8 +364,6 @@ class DataSynchronizationService
 
             if (!$worklog) {
                 $worklog = new Worklog();
-
-                $dataProvider = $this->dataProviderRepository->find($dataProviderId);
 
                 $worklog->setDataProvider($dataProvider);
 
@@ -400,12 +379,8 @@ class DataSynchronizationService
                 ->setTimeSpentSeconds($worklogDatum->timeSpentSeconds)
                 ->setTimeSpentSeconds($worklogDatum->timeSpentSeconds)
                 ->setIssue($issue)
-                ->setKind(BillableKindsEnum::tryFrom($worklogDatum->kind));
-
-            if (null != $worklog->getProjectTrackerIssueId()) {
-                $issue = $this->issueRepository->findOneBy(['projectTrackerId' => $worklog->getProjectTrackerIssueId()]);
-                $worklog->setIssue($issue);
-            }
+                ->setKind(BillableKindsEnum::tryFrom($worklogDatum->kind))
+                ->setIssue($issue);
 
             if (null === $worklog->isBilled()) {
                 $worklog->setIsBilled(false);
@@ -420,7 +395,7 @@ class DataSynchronizationService
             }
 
             if (null !== $progressCallback) {
-                $progressCallback($worklogsAdded, count($worklogData->worklogData));
+                $progressCallback($worklogsAdded, $worklogsCount);
 
                 ++$worklogsAdded;
             }
@@ -428,21 +403,13 @@ class DataSynchronizationService
             $workerEmail = $worklog->getWorker();
 
             if ($workerEmail && filter_var($workerEmail, FILTER_VALIDATE_EMAIL)) {
-                $worker = $this->workerRepository->findOneBy(['email' => $workerEmail]);
-
-                if (!$worker) {
-                    $worker = new Worker();
-                    $worker->setEmail($workerEmail);
-
-                    $this->entityManager->persist($worker);
-                    $this->entityManager->flush();
-                }
+                $this->getWorker($workerEmail);
             }
 
             // Flush and clear for each batch.
             if (0 === $worklogsAdded % self::BATCH_SIZE) {
                 $this->entityManager->flush();
-                $this->entityManager->clear();
+                $this->clear();
             }
         }
 
@@ -454,7 +421,7 @@ class DataSynchronizationService
         }
 
         $this->entityManager->flush();
-        $this->entityManager->clear();
+        $this->clear();
     }
 
     /**
@@ -554,5 +521,107 @@ class DataSynchronizationService
 
         // Save changes to the database
         $this->entityManager->flush();
+    }
+
+    private function getWorker(string $email): Worker
+    {
+        if (isset($this->workers[$email])) {
+            return $this->workers[$email];
+        }
+
+        $worker = $this->workerRepository->findOneBy([
+            'email' => $email,
+        ]);
+
+        if (null === $worker) {
+            $worker = new Worker();
+            $worker->setEmail($email);
+            $this->entityManager->persist($worker);
+        }
+
+        $this->workers[$email] = $worker;
+
+        return $worker;
+    }
+
+    private function getIssue(string $projectTrackerIssueId, DataProvider $dataProvider): ?Issue
+    {
+        if (isset($this->issues[$projectTrackerIssueId])) {
+            return $this->issues[$projectTrackerIssueId];
+        }
+
+        $issue = $this->issueRepository->findOneBy([
+            'projectTrackerId' => $projectTrackerIssueId,
+            'dataProvider' => $dataProvider,
+        ]);
+
+        $this->issues[$projectTrackerIssueId] = $issue;
+
+        return $issue;
+    }
+
+    private function getVersion(string $projectTrackerId, DataProvider $dataProvider): ?Version
+    {
+        if (isset($this->versions[$projectTrackerId])) {
+            return $this->versions[$projectTrackerId];
+        }
+
+        $version = $this->versionRepository->findOneBy([
+            'projectTrackerId' => $projectTrackerId,
+            'dataProvider' => $dataProvider,
+        ]);
+
+        $this->versions[$projectTrackerId] = $version;
+
+        return $version;
+    }
+
+    private function getEpic(string $title): ?Epic
+    {
+        if (isset($this->epics[$title])) {
+            return $this->epics[$title];
+        }
+
+        $epic = $this->epicRepository->findOneBy(['title' => $title]);
+
+        $this->epics[$title] = $epic;
+
+        return $epic;
+    }
+
+    private function getProject(Project $project): Project
+    {
+        if (!$this->entityManager->contains($project)) {
+            $project = $this->projectRepository->find($project->getId());
+        }
+
+        if (null === $project) {
+            throw new \RuntimeException('Project not found');
+        }
+
+        return $project;
+    }
+
+    private function getDataProvider(DataProvider $dataProvider): DataProvider
+    {
+        if (!$this->entityManager->contains($dataProvider)) {
+            $dataProvider = $this->dataProviderRepository->find($dataProvider->getId());
+        }
+
+        if (null === $dataProvider) {
+            throw new \RuntimeException('DataProvider not found');
+        }
+
+        return $dataProvider;
+    }
+
+    private function clear(): void
+    {
+        $this->workers = [];
+        $this->issues = [];
+        $this->versions = [];
+        $this->epics = [];
+
+        $this->entityManager->clear();
     }
 }

--- a/templates/components/sync-status.html.twig
+++ b/templates/components/sync-status.html.twig
@@ -1,7 +1,8 @@
 <div class="mt-5 selections p-5" {{ stimulus_controller('sync-status') }} data-interval="60">
     <div style="display: flex; flex-direction: row; justify-content: space-between; margin-bottom: .25em">
         <span>{{ 'sync_status.header'|trans }}</span>
-        <button class="button hidden" style="padding: .25em .5em; margin-left: .5em"
+        {# @TODO re-enable button when sync is fully re-factored #}
+        <button disabled class="button hidden btn-disabled" style="padding: .25em .5em; margin-left: .5em"
             {{ stimulus_action('sync-status', 'run') }} {{ stimulus_target('sync-status', 'button') }}>
             {{ 'sync_status.button'|trans }}
         </button>


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban#/tickets/showTicket/4127

#### Description

Fixes and optimizations for `app:sync` command:
* Fixed the way `SynchronizationJob` was saved to the DB after edits which was causing duplicates
* Fixed `SynchronizationJob` becomming detached after èntitymanager->clear()` which was causing duplicates
* Removed redundant DB queries
* `app:sync` command now saves progress to DB
* `app:sync` command now calls monitoring URL

Note:
The sync functionality could still benefit from being re-factored. This PR doesn't address the code duplication and multiple code-paths that currently exist. 

I have tried to focus on making sure progress/completion is shown again and to optimize execution time where this could be done with limited changes to program flow to limit the risk of new bugs being introduced. 

#### Screenshot of the result

Before on local machine
```
real	9m18.758s
user	0m0.164s
sys 	0m0.182s
```
After
```
real	5m0.856s
user	0m0.124s
sys 	0m0.178s
```

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
