### PR TITLE
7207: WorkloadReport - right-align numbers and use 1 decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-292](https://github.com/itk-dev/economics/pull/292)
+  Workload report: right-align numbers and round percentages to 1 decimal.
 * [PR-290](https://github.com/itk-dev/economics/pull/290)
   Sort reports alphabetically - unbilled projects report, hour report, invoicing rate report, workload report.
 

--- a/src/Service/WorkloadReportService.php
+++ b/src/Service/WorkloadReportService.php
@@ -92,7 +92,7 @@ class WorkloadReportService
                 }
 
                 $expectedWorkload = $this->getExpectedWorkHours($workerWorkload, $viewPeriodType, $dateFrom, $dateTo);
-                $roundedLoggedPercentage = round($loggedHours / $expectedWorkload * 100, 2);
+                $roundedLoggedPercentage = round($loggedHours / $expectedWorkload * 100, 1);
 
                 // Count up sums until current period have been reached.
                 if (!$currentPeriodReached) {
@@ -108,11 +108,11 @@ class WorkloadReportService
                 $periodCounts[$period] = ($periodCounts[$period] ?? 0) + 1;
 
                 // Calculate and set the average for this period
-                $average = round($periodSums[$period] / $periodCounts[$period], 2);
+                $average = round($periodSums[$period] / $periodCounts[$period], 1);
                 $workloadReportData->periodAverages->set($period, $average);
             }
 
-            $workloadReportWorker->average = $expectedWorkloadSum > 0 ? round($loggedHoursSum / $expectedWorkloadSum * 100, 2) : 0;
+            $workloadReportWorker->average = $expectedWorkloadSum > 0 ? round($loggedHoursSum / $expectedWorkloadSum * 100, 1) : 0;
 
             $workloadReportData->workers->add($workloadReportWorker);
         }
@@ -127,7 +127,7 @@ class WorkloadReportService
 
         // Calculate the total average of averages
         if ($numberOfPeriods > 0) {
-            $workloadReportData->totalAverage = round($averageSum / $numberOfPeriods, 2);
+            $workloadReportData->totalAverage = round($averageSum / $numberOfPeriods, 1);
         }
 
         return $workloadReportData;

--- a/templates/reports/workload_report.html.twig
+++ b/templates/reports/workload_report.html.twig
@@ -50,18 +50,18 @@
                         </button>
                     </div>
                 </td>
-                <td class="text-center px-3 border border-slate-600">
+                <td class="text-right px-3 border border-slate-600">
                     {{ worker.workload }}
                 </td>
                 {% for periodNumeric, week in worker.loggedPercentage %}
-                    <td class="text-center px-3 border border-slate-600
+                    <td class="text-right px-3 border border-slate-600
 {{ (data.currentPeriodNumeric is defined) and (periodNumeric is same as(data.currentPeriodNumeric)) ? 'bg-slate-300 dark:bg-slate-800' : '' }}
 ">
-                        {{ week ~ '%' }}
+                        {{ week|round(1) ~ '%' }}
                     </td>
                 {% endfor %}
-                <td class="text-center px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800">
-                    {{ worker.average ~ '%' }}
+                <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800">
+                    {{ worker.average|round(1) ~ '%' }}
                 </td>
             </tr>
             </tbody>
@@ -71,14 +71,14 @@
             <td class="text-left py-2 px-2 sticky left-0 z-10 whitespace-nowrap border border-slate-600 bg-slate-300 dark:bg-slate-800">
                 {{ 'workload_report.average'|trans }}
             </td>
-            <td class="text-center px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"></td>
+            <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"></td>
             {% for periodNumeric, period in data.period %}
-                <td class="text-center px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800
+                <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800
                 ">
-                    {{ data.periodAverages[periodNumeric] ~ '%' }}
+                    {{ data.periodAverages[periodNumeric]|round(1) ~ '%' }}
                 </td>
             {% endfor %}
-            <td class="text-center px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"> {{ data.totalAverage ~ '%' }}</td>
+            <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"> {{ data.totalAverage|round(1) ~ '%' }}</td>
         </tr>
         </tbody>
     </table>

--- a/templates/reports/workload_report.html.twig
+++ b/templates/reports/workload_report.html.twig
@@ -57,11 +57,11 @@
                     <td class="text-right px-3 border border-slate-600
 {{ (data.currentPeriodNumeric is defined) and (periodNumeric is same as(data.currentPeriodNumeric)) ? 'bg-slate-300 dark:bg-slate-800' : '' }}
 ">
-                        {{ week|round(1) ~ '%' }}
+                        {{ week ~ '%' }}
                     </td>
                 {% endfor %}
                 <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800">
-                    {{ worker.average|round(1) ~ '%' }}
+                    {{ worker.average ~ '%' }}
                 </td>
             </tr>
             </tbody>
@@ -75,10 +75,10 @@
             {% for periodNumeric, period in data.period %}
                 <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800
                 ">
-                    {{ data.periodAverages[periodNumeric]|round(1) ~ '%' }}
+                    {{ data.periodAverages[periodNumeric] ~ '%' }}
                 </td>
             {% endfor %}
-            <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"> {{ data.totalAverage|round(1) ~ '%' }}</td>
+            <td class="text-right px-3 border border-slate-600 bg-slate-300 dark:bg-slate-800"> {{ data.totalAverage ~ '%' }}</td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
#### Link to ticket

[#7207](https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/7207)

#### Description

Changes for workload report:
Right-align numbers and round percentages to 1 decimal in workload report

#### Screenshot of the result

Before:
<img width="439" height="641" alt="Screenshot 2026-05-04 at 13 53 57" src="https://github.com/user-attachments/assets/77ffd3eb-c6da-4589-be8e-76c9e81838e5" />

After:
<img width="393" height="642" alt="Screenshot 2026-05-04 at 13 52 23" src="https://github.com/user-attachments/assets/039630f5-05e3-4cc7-80eb-126d67ae433a" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
