### PR TITLE
7808: External invoice quality-of-life

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,9 @@ API_SERVICE_SPRINT_NAME_REGEX="/(?<weeks>(?:-?\d+-?)*)\.(?<year>\d+)$/"
 APP_WEEK_GOAL_LOW=25.0
 APP_WEEK_GOAL_HIGH=34.5
 APP_INVOICE_SUPPLIER_ACCOUNT=APP_INVOICE_SUPPLIER_ACCOUNT
+# The receiver account value ("ITK Dev Ekstern") required on external invoices
+# before they can be recorded. Leave empty to disable the check.
+APP_INVOICE_EXTERNAL_RECEIVER_ACCOUNT=
 APP_INVOICE_DESCRIPTION_TEMPLATE="Spørgsmål vedrørende fakturaen rettes til %name%, %email%."
 APP_PROJECT_BILLING_DEFAULT_DESCRIPTION=
 APP_HTTP_CLIENT_RETRY_DELAY_MS=1000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-318](https://github.com/itk-dev/economics/pull/318)
+  * Quality-of-life improvements for external invoices.
+
 ## [3.5.0] - 2026-05-26
 
 * [PR-315](https://github.com/itk-dev/economics/pull/315)

--- a/assets/controllers/autofill-material-number_controller.js
+++ b/assets/controllers/autofill-material-number_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus";
+
+/** Autofills the invoice material number from the selected client's type. */
+export default class extends Controller {
+    static targets = ["client", "material"];
+
+    static values = { map: Object };
+
+    update() {
+        const materialNumber = this.mapValue[this.clientTarget.value];
+
+        if (!materialNumber) {
+            return;
+        }
+
+        this.materialTarget.value = materialNumber;
+        this.materialTarget.dispatchEvent(
+            new Event("change", { bubbles: true }),
+        );
+    }
+}

--- a/assets/controllers/autofill-material-number_controller.js
+++ b/assets/controllers/autofill-material-number_controller.js
@@ -7,12 +7,10 @@ export default class extends Controller {
     static values = { map: Object };
 
     update() {
-        const materialNumber = this.mapValue[this.clientTarget.value];
-
-        if (!materialNumber) {
-            return;
-        }
-
-        this.materialTarget.value = materialNumber;
+        // Reflect the selected client's implied material number. Clients with no
+        // type (and the empty "no client" option) map to "", which resets the
+        // field to the empty NONE option rather than leaving a stale value.
+        this.materialTarget.value =
+            this.mapValue[this.clientTarget.value] ?? "";
     }
 }

--- a/assets/controllers/autofill-material-number_controller.js
+++ b/assets/controllers/autofill-material-number_controller.js
@@ -14,8 +14,5 @@ export default class extends Controller {
         }
 
         this.materialTarget.value = materialNumber;
-        this.materialTarget.dispatchEvent(
-            new Event("change", { bubbles: true }),
-        );
     }
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,6 +17,7 @@ services:
         bind:
             $defaultInvoiceDescriptionTemplate: "%env(APP_INVOICE_DESCRIPTION_TEMPLATE)%"
             $invoiceSupplierAccount: "%env(string:APP_INVOICE_SUPPLIER_ACCOUNT)%"
+            $invoiceExternalReceiverAccount: "%env(string:APP_INVOICE_EXTERNAL_RECEIVER_ACCOUNT)%"
             $projectBillingDefaultDescription: "%env(string:APP_PROJECT_BILLING_DEFAULT_DESCRIPTION)%"
 
     # makes classes in src/ available to be used as services

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3640,13 +3640,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Repository\\ClientRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 4
 			path: tests/Unit/Service/ProjectBillingServiceTest.php
 
 		-
 			message: '#^Call to an undefined method App\\Repository\\IssueRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 10
+			count: 11
 			path: tests/Unit/Service/ProjectBillingServiceTest.php
 
 		-
@@ -3658,7 +3658,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Repository\\ProjectBillingRepository\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 9
+			count: 10
 			path: tests/Unit/Service/ProjectBillingServiceTest.php
 
 		-
@@ -3676,7 +3676,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method App\\Service\\ClientHelper\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 3
 			path: tests/Unit/Service/ProjectBillingServiceTest.php
 
 		-
@@ -3688,7 +3688,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method Doctrine\\ORM\\EntityManagerInterface\:\:method\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 3
 			path: tests/Unit/Service/ProjectBillingServiceTest.php
 
 		-

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -166,7 +166,8 @@ class InvoiceController extends AbstractController
         // autofill the material number when a client is selected.
         $clientMaterialNumbers = [];
         foreach ($clientChoices as $clientChoice) {
-            $clientMaterialNumbers[$clientChoice->getId()] = $clientChoice->getType()?->toMaterialNumber()->value ?? '';
+            $type = $clientChoice->getType();
+            $clientMaterialNumbers[$clientChoice->getId()] = null !== $type ? $type->toMaterialNumber()->value : '';
         }
 
         $form->handleRequest($request);

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Client;
 use App\Entity\Invoice;
 use App\Entity\InvoiceEntry;
 use App\Exception\EconomicsException;
@@ -153,10 +154,20 @@ class InvoiceController extends AbstractController
             'attr' => [
                 'class' => 'form-element',
                 'data-choices-target' => 'choices',
+                'data-autofill-material-number-target' => 'client',
+                'data-action' => 'change->autofill-material-number#update',
             ],
             'help' => 'invoices.client_helptext',
             'choices' => $clientChoices,
+            'choice_value' => fn (?Client $client) => $client?->getId(),
         ]);
+
+        // Map each client to the material number its type implies, so the form can
+        // autofill the material number when a client is selected.
+        $clientMaterialNumbers = [];
+        foreach ($clientChoices as $clientChoice) {
+            $clientMaterialNumbers[$clientChoice->getId()] = $clientChoice->getType()?->toMaterialNumber()->value ?? '';
+        }
 
         $form->handleRequest($request);
 
@@ -197,6 +208,7 @@ class InvoiceController extends AbstractController
                 return $carry;
             }, 0.0),
             'clientHelper' => $clientHelper,
+            'clientMaterialNumbers' => $clientMaterialNumbers,
         ]);
     }
 

--- a/src/Controller/ProjectBillingController.php
+++ b/src/Controller/ProjectBillingController.php
@@ -228,7 +228,7 @@ class ProjectBillingController extends AbstractController
 
                 return match ($type) {
                     ClientTypeEnum::INTERNAL->value => ClientTypeEnum::INTERNAL === $clientType,
-                    ClientTypeEnum::EXTERNAL->value => (bool) $clientType?->isExternal(),
+                    ClientTypeEnum::EXTERNAL->value => true === $clientType?->isExternal(),
                     default => $clientType?->value === $type,
                 };
             });

--- a/src/Controller/ProjectBillingController.php
+++ b/src/Controller/ProjectBillingController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Invoice;
 use App\Entity\ProjectBilling;
+use App\Enum\ClientTypeEnum;
 use App\Exception\EconomicsException;
 use App\Form\ProjectBillingFilterType;
 use App\Form\ProjectBillingRecordType;
@@ -218,9 +219,19 @@ class ProjectBillingController extends AbstractController
         $invoices = $projectBilling->getInvoices();
 
         // Filter invoices by client.type if type query parameter is set.
+        // "external" matches every external variant (e.g. with/without moms),
+        // since they are all external clients.
         $type = $request->query->get('type');
         if (null !== $type) {
-            $invoices = $invoices->filter(fn (Invoice $invoice) => $invoice->getClient()?->getType()?->value == $type);
+            $invoices = $invoices->filter(function (Invoice $invoice) use ($type) {
+                $clientType = $invoice->getClient()?->getType();
+
+                return match ($type) {
+                    ClientTypeEnum::INTERNAL->value => ClientTypeEnum::INTERNAL === $clientType,
+                    ClientTypeEnum::EXTERNAL->value => (bool) $clientType?->isExternal(),
+                    default => $clientType?->value === $type,
+                };
+            });
         }
 
         // Mark invoice as exported.

--- a/src/Enum/ClientTypeEnum.php
+++ b/src/Enum/ClientTypeEnum.php
@@ -5,5 +5,31 @@ namespace App\Enum;
 enum ClientTypeEnum: string
 {
     case INTERNAL = 'internal';
+    // Legacy value kept for backwards compatibility with existing client rows.
     case EXTERNAL = 'external';
+    case EXTERNAL_WITH_MOMS = 'external_with_moms';
+    case EXTERNAL_WITHOUT_MOMS = 'external_without_moms';
+
+    public function isExternal(): bool
+    {
+        return match ($this) {
+            self::EXTERNAL, self::EXTERNAL_WITH_MOMS, self::EXTERNAL_WITHOUT_MOMS => true,
+            self::INTERNAL => false,
+        };
+    }
+
+    /**
+     * The material number a client type maps to on its invoices.
+     *
+     * Legacy "external" carries no moms distinction, so it keeps the previous
+     * default of "with moms".
+     */
+    public function toMaterialNumber(): MaterialNumberEnum
+    {
+        return match ($this) {
+            self::INTERNAL => MaterialNumberEnum::INTERNAL,
+            self::EXTERNAL_WITHOUT_MOMS => MaterialNumberEnum::EXTERNAL_WITHOUT_MOMS,
+            self::EXTERNAL, self::EXTERNAL_WITH_MOMS => MaterialNumberEnum::EXTERNAL_WITH_MOMS,
+        };
+    }
 }

--- a/src/Enum/MaterialNumberEnum.php
+++ b/src/Enum/MaterialNumberEnum.php
@@ -13,7 +13,7 @@ enum MaterialNumberEnum: string
     {
         return match ($this) {
             self::EXTERNAL_WITH_MOMS, self::EXTERNAL_WITHOUT_MOMS => true,
-            default => false,
+            self::NONE, self::INTERNAL => false,
         };
     }
 }

--- a/src/Enum/MaterialNumberEnum.php
+++ b/src/Enum/MaterialNumberEnum.php
@@ -8,4 +8,12 @@ enum MaterialNumberEnum: string
     case INTERNAL = '103361';
     case EXTERNAL_WITH_MOMS = '100006';
     case EXTERNAL_WITHOUT_MOMS = '100008';
+
+    public function isExternal(): bool
+    {
+        return match ($this) {
+            self::EXTERNAL_WITH_MOMS, self::EXTERNAL_WITHOUT_MOMS => true,
+            default => false,
+        };
+    }
 }

--- a/src/Form/ClientType.php
+++ b/src/Form/ClientType.php
@@ -13,6 +13,8 @@ use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -52,25 +54,11 @@ class ClientType extends AbstractType
                 'required' => false,
                 'row_attr' => ['class' => 'form-row'],
                 'html5' => true,
-            ])
-            ->add('type', EnumType::class, [
-                'class' => ClientTypeEnum::class,
-                'choices' => $this->getTypeOptions($builder->getData()),
-                'label' => 'create_client_form.type.label',
-                'label_attr' => ['class' => 'label'],
-                'choice_label' => fn ($choice) => match ($choice) {
-                    ClientTypeEnum::INTERNAL => 'client_type_enum.internal',
-                    ClientTypeEnum::EXTERNAL => 'client_type_enum.external',
-                    ClientTypeEnum::EXTERNAL_WITH_MOMS => 'client_type_enum.external_with_moms',
-                    ClientTypeEnum::EXTERNAL_WITHOUT_MOMS => 'client_type_enum.external_without_moms',
-                    default => null,
-                },
-                'attr' => ['class' => 'form-element'],
-                'help_attr' => ['class' => 'form-help'],
-                'help' => 'create_client_form.type.help',
-                'required' => true,
-                'row_attr' => ['class' => 'form-row'],
-            ])
+            ]);
+
+        $builder->add('type', EnumType::class, $this->typeFieldOptions($builder->getData()));
+
+        $builder
             ->add('customerKey', TextType::class, [
                 'label' => 'create_client_form.customer_key.label',
                 'label_attr' => ['class' => 'label'],
@@ -107,6 +95,39 @@ class ClientType extends AbstractType
                 'required' => false,
                 'choices' => $this->getVersionOptions($builder->getData()),
             ]);
+
+        // The available type choices depend on the bound client (the legacy
+        // "external" value stays selectable only while a client still uses it),
+        // so rebuild the field from the actual data once it is set on the form.
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+            $client = $event->getData();
+            $event->getForm()->add('type', EnumType::class, $this->typeFieldOptions($client instanceof Client ? $client : null));
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function typeFieldOptions(?Client $client): array
+    {
+        return [
+            'class' => ClientTypeEnum::class,
+            'choices' => $this->getTypeOptions($client),
+            'label' => 'create_client_form.type.label',
+            'label_attr' => ['class' => 'label'],
+            'choice_label' => fn ($choice) => match ($choice) {
+                ClientTypeEnum::INTERNAL => 'client_type_enum.internal',
+                ClientTypeEnum::EXTERNAL => 'client_type_enum.external',
+                ClientTypeEnum::EXTERNAL_WITH_MOMS => 'client_type_enum.external_with_moms',
+                ClientTypeEnum::EXTERNAL_WITHOUT_MOMS => 'client_type_enum.external_without_moms',
+                default => null,
+            },
+            'attr' => ['class' => 'form-element'],
+            'help_attr' => ['class' => 'form-help'],
+            'help' => 'create_client_form.type.help',
+            'required' => true,
+            'row_attr' => ['class' => 'form-row'],
+        ];
     }
 
     /**

--- a/src/Form/ClientType.php
+++ b/src/Form/ClientType.php
@@ -55,11 +55,14 @@ class ClientType extends AbstractType
             ])
             ->add('type', EnumType::class, [
                 'class' => ClientTypeEnum::class,
+                'choices' => $this->getTypeOptions($builder->getData()),
                 'label' => 'create_client_form.type.label',
                 'label_attr' => ['class' => 'label'],
                 'choice_label' => fn ($choice) => match ($choice) {
                     ClientTypeEnum::INTERNAL => 'client_type_enum.internal',
                     ClientTypeEnum::EXTERNAL => 'client_type_enum.external',
+                    ClientTypeEnum::EXTERNAL_WITH_MOMS => 'client_type_enum.external_with_moms',
+                    ClientTypeEnum::EXTERNAL_WITHOUT_MOMS => 'client_type_enum.external_without_moms',
                     default => null,
                 },
                 'attr' => ['class' => 'form-element'],
@@ -104,6 +107,25 @@ class ClientType extends AbstractType
                 'required' => false,
                 'choices' => $this->getVersionOptions($builder->getData()),
             ]);
+    }
+
+    /**
+     * @return ClientTypeEnum[]
+     */
+    private function getTypeOptions(?Client $client): array
+    {
+        $choices = [
+            ClientTypeEnum::INTERNAL,
+            ClientTypeEnum::EXTERNAL_WITH_MOMS,
+            ClientTypeEnum::EXTERNAL_WITHOUT_MOMS,
+        ];
+
+        // Keep the legacy "external" option available only for clients still using it.
+        if (ClientTypeEnum::EXTERNAL === $client?->getType()) {
+            $choices[] = ClientTypeEnum::EXTERNAL;
+        }
+
+        return $choices;
     }
 
     private function getVersionOptions(?Client $client): array

--- a/src/Form/InvoiceType.php
+++ b/src/Form/InvoiceType.php
@@ -67,7 +67,7 @@ class InvoiceType extends AbstractType
                 'label' => 'invoices.default_material_number',
                 'label_attr' => ['class' => 'label'],
                 'row_attr' => ['class' => 'form-row'],
-                'attr' => ['class' => 'form-element'],
+                'attr' => ['class' => 'form-element', 'data-autofill-material-number-target' => 'material'],
                 'help' => 'invoices.default_material_number_helptext',
                 'choice_label' => fn ($choice) => match ($choice) {
                     MaterialNumberEnum::NONE => '',

--- a/src/Service/BillingService.php
+++ b/src/Service/BillingService.php
@@ -28,6 +28,7 @@ class BillingService
         private readonly InvoiceEntryRepository $invoiceEntryRepository,
         private readonly TranslatorInterface $translator,
         private readonly string $invoiceSupplierAccount,
+        private readonly string $invoiceExternalReceiverAccount = '',
     ) {
     }
 
@@ -150,7 +151,48 @@ class BillingService
             }
         }
 
+        // These extra checks target manually created external invoices. Project billing
+        // generates its external invoices automatically (with the default receiver account),
+        // so they are exempt; individual project billing invoices cannot be recorded here anyway.
+        if (null === $invoice->getProjectBilling() && $this->isExternalInvoice($invoice)) {
+            // Receiver account must be the dedicated external account ("ITK Dev Ekstern").
+            // Skip when no external account is configured; we cannot validate against an unknown account.
+            if ('' !== $this->invoiceExternalReceiverAccount
+                && $invoice->getDefaultReceiverAccount() !== $this->invoiceExternalReceiverAccount) {
+                $errors[] = $this->translator->trans('invoice_recordable.error_external_receiver_account');
+            }
+
+            if (is_null($invoice->getPeriodFrom()) || is_null($invoice->getPeriodTo())) {
+                $errors[] = $this->translator->trans('invoice_recordable.error_external_missing_period');
+            }
+
+            $projectName = $invoice->getProject()?->getName();
+            if (!empty($projectName)
+                && !str_contains(mb_strtolower($invoice->getDescription() ?? ''), mb_strtolower($projectName))) {
+                $errors[] = $this->translator->trans('invoice_recordable.error_external_description_missing_project_name');
+            }
+        }
+
         return $errors;
+    }
+
+    /**
+     * An invoice is external when its default material number, or any of its
+     * entries' material numbers, is an external one.
+     */
+    private function isExternalInvoice(Invoice $invoice): bool
+    {
+        if ($invoice->getDefaultMaterialNumber()?->isExternal()) {
+            return true;
+        }
+
+        foreach ($invoice->getInvoiceEntries() as $invoiceEntry) {
+            if ($invoiceEntry->getMaterialNumber()?->isExternal()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Service/ProjectBillingService.php
+++ b/src/Service/ProjectBillingService.php
@@ -8,7 +8,6 @@ use App\Entity\InvoiceEntry;
 use App\Entity\Issue;
 use App\Entity\ProjectBilling;
 use App\Entity\Worklog;
-use App\Enum\ClientTypeEnum;
 use App\Enum\InvoiceEntryTypeEnum;
 use App\Enum\MaterialNumberEnum;
 use App\Exception\EconomicsException;
@@ -194,10 +193,8 @@ class ProjectBillingService
             $invoice->setPeriodTo($periodEnd);
             $invoice->setClient($client);
 
-            $internal = ClientTypeEnum::INTERNAL == $client->getType();
-
-            // TODO: MaterialNumberEnum::EXTERNAL_WITH_MOMS or MaterialNumberEnum::EXTERNAL_WITHOUT_MOMS?
-            $invoice->setDefaultMaterialNumber($internal ? MaterialNumberEnum::INTERNAL : MaterialNumberEnum::EXTERNAL_WITH_MOMS);
+            // A client without a type is treated as external with moms (the previous default).
+            $invoice->setDefaultMaterialNumber($client->getType()?->toMaterialNumber() ?? MaterialNumberEnum::EXTERNAL_WITH_MOMS);
             $invoice->setDefaultReceiverAccount($this->invoiceEntryHelper->getDefaultAccount());
 
             /** @var Issue $issue */

--- a/templates/invoices/edit.html.twig
+++ b/templates/invoices/edit.html.twig
@@ -8,7 +8,7 @@
     }) }}
 
     {{ form_start(form) }}
-    <div class="grid-split selections" {{ stimulus_controller('choices') }}>
+    <div class="grid-split selections" {{ stimulus_controller('choices')|stimulus_controller('autofill-material-number', {map: clientMaterialNumbers}) }}>
         <div>
             {{ form_row(form.name) }}
             <div {{ stimulus_controller('generate-description') }} data-endpoint="{{ path('app_invoices_generate_description', {id: invoice.id}) }}">

--- a/templates/invoices/edit.html.twig
+++ b/templates/invoices/edit.html.twig
@@ -49,8 +49,7 @@
                     <li class="list-group-item border-bottom">
                         {{ 'invoices.client_type'|trans }}:
                         {% if invoice.client.type is not null %}
-                            {{ invoice.client.type.value == 'internal' ? 'invoices.client_type_internal'|trans : '' }}
-                            {{ invoice.client.type.value == 'external' ? 'invoices.client_type_external'|trans : '' }}
+                            {{ invoice.client.type.value == 'internal' ? 'invoices.client_type_internal'|trans : 'invoices.client_type_external'|trans }}
                         {% else %}
                             {{ 'invoices.client_type_is_null'|trans }}
                         {% endif %}

--- a/templates/project_billing/edit.html.twig
+++ b/templates/project_billing/edit.html.twig
@@ -48,8 +48,7 @@
                 <td class="table-td">{{ invoice.name }}</td>
                 <td class="table-td">
                     {% if invoice.client.type != null %}
-                        {{ invoice.client.type.value == 'internal' ? 'invoices.client_type_internal'|trans : '' }}
-                        {{ invoice.client.type.value == 'external' ? 'invoices.client_type_external'|trans : '' }}
+                        {{ invoice.client.type.value == 'internal' ? 'invoices.client_type_internal'|trans : 'invoices.client_type_external'|trans }}
                     {% endif %}
                 </td>
                 <td class="table-td">{{ invoice.totalPrice }}</td>

--- a/tests/Integration/Controller/InvoiceFullFlowTest.php
+++ b/tests/Integration/Controller/InvoiceFullFlowTest.php
@@ -53,6 +53,13 @@ class InvoiceFullFlowTest extends AbstractControllerTestCase
         $crawler = $client->request('GET', '/admin/invoices/'.$invoiceId.'/edit');
         $this->assertResponseIsSuccessful();
 
+        // The client select autofills the material number via a Stimulus controller.
+        $editHtml = (string) $client->getResponse()->getContent();
+        $this->assertStringContainsString('data-autofill-material-number-map-value', $editHtml);
+        $this->assertStringContainsString('data-autofill-material-number-target="client"', $editHtml);
+        $this->assertStringContainsString('data-autofill-material-number-target="material"', $editHtml);
+        $this->assertStringContainsString('autofill-material-number#update', $editHtml);
+
         $finalName = 'FullFlow-edit-'.uniqid();
         $description = 'Full flow invoice description.';
         $periodFrom = '2025-01-01';

--- a/tests/Unit/Enum/ClientTypeEnumTest.php
+++ b/tests/Unit/Enum/ClientTypeEnumTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\Unit\Enum;
+
+use App\Enum\ClientTypeEnum;
+use App\Enum\MaterialNumberEnum;
+use PHPUnit\Framework\TestCase;
+
+class ClientTypeEnumTest extends TestCase
+{
+    public function testInternalIsNotExternal(): void
+    {
+        $this->assertFalse(ClientTypeEnum::INTERNAL->isExternal());
+    }
+
+    /**
+     * @dataProvider externalTypesProvider
+     */
+    public function testExternalVariantsAreExternal(ClientTypeEnum $type): void
+    {
+        $this->assertTrue($type->isExternal());
+    }
+
+    /**
+     * @return array<string, array{ClientTypeEnum}>
+     */
+    public static function externalTypesProvider(): array
+    {
+        return [
+            'legacy external' => [ClientTypeEnum::EXTERNAL],
+            'external with moms' => [ClientTypeEnum::EXTERNAL_WITH_MOMS],
+            'external without moms' => [ClientTypeEnum::EXTERNAL_WITHOUT_MOMS],
+        ];
+    }
+
+    /**
+     * @dataProvider materialNumberProvider
+     */
+    public function testToMaterialNumber(ClientTypeEnum $type, MaterialNumberEnum $expected): void
+    {
+        $this->assertSame($expected, $type->toMaterialNumber());
+    }
+
+    /**
+     * @return array<string, array{ClientTypeEnum, MaterialNumberEnum}>
+     */
+    public static function materialNumberProvider(): array
+    {
+        return [
+            'internal' => [ClientTypeEnum::INTERNAL, MaterialNumberEnum::INTERNAL],
+            'with moms' => [ClientTypeEnum::EXTERNAL_WITH_MOMS, MaterialNumberEnum::EXTERNAL_WITH_MOMS],
+            'without moms' => [ClientTypeEnum::EXTERNAL_WITHOUT_MOMS, MaterialNumberEnum::EXTERNAL_WITHOUT_MOMS],
+            'legacy external defaults to with moms' => [ClientTypeEnum::EXTERNAL, MaterialNumberEnum::EXTERNAL_WITH_MOMS],
+        ];
+    }
+}

--- a/tests/Unit/Service/BillingServiceTest.php
+++ b/tests/Unit/Service/BillingServiceTest.php
@@ -6,6 +6,7 @@ use App\Entity\Client;
 use App\Entity\Invoice;
 use App\Entity\InvoiceEntry;
 use App\Entity\IssueProduct;
+use App\Entity\Project;
 use App\Entity\Worklog;
 use App\Enum\ClientTypeEnum;
 use App\Enum\InvoiceEntryTypeEnum;
@@ -38,7 +39,37 @@ class BillingServiceTest extends TestCase
             $this->invoiceEntryRepository,
             $this->translator,
             '1234567890',
+            'EXTERNAL-PSP',
         );
+    }
+
+    private function createExternalInvoice(): Invoice
+    {
+        $client = new Client();
+        $client->setName('External Client');
+        $client->setContact('Jane Doe');
+        $client->setType(ClientTypeEnum::EXTERNAL);
+
+        $project = new Project();
+        $project->setName('Acme project');
+
+        $entry = new InvoiceEntry();
+        $entry->setEntryType(InvoiceEntryTypeEnum::MANUAL);
+        $entry->setAmount(5.0);
+
+        $invoice = new Invoice();
+        $invoice->setName('Test');
+        $invoice->setRecorded(false);
+        $invoice->setClient($client);
+        $invoice->setProject($project);
+        $invoice->setDefaultMaterialNumber(MaterialNumberEnum::EXTERNAL_WITH_MOMS);
+        $invoice->setDefaultReceiverAccount('EXTERNAL-PSP');
+        $invoice->setPeriodFrom(new \DateTime('2024-01-01'));
+        $invoice->setPeriodTo(new \DateTime('2024-01-31'));
+        $invoice->setDescription('Invoice for Acme project, January.');
+        $invoice->addInvoiceEntry($entry);
+
+        return $invoice;
     }
 
     public function testUpdateInvoiceEntryTotalPriceWorklogType(): void
@@ -384,6 +415,75 @@ class BillingServiceTest extends TestCase
         $invoice->setRecorded(false);
         $invoice->setClient($client);
         $invoice->addInvoiceEntry($entry);
+
+        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsValidExternalInvoice(): void
+    {
+        $errors = $this->billingService->getInvoiceRecordableErrors($this->createExternalInvoice());
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsExternalWrongReceiverAccount(): void
+    {
+        $invoice = $this->createExternalInvoice();
+        $invoice->setDefaultReceiverAccount('SOME-OTHER-ACCOUNT');
+
+        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
+
+        $this->assertContains('invoice_recordable.error_external_receiver_account', $errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsExternalMissingPeriod(): void
+    {
+        $invoice = $this->createExternalInvoice();
+        $invoice->setPeriodFrom(null);
+
+        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
+
+        $this->assertContains('invoice_recordable.error_external_missing_period', $errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsExternalDescriptionMissingProjectName(): void
+    {
+        $invoice = $this->createExternalInvoice();
+        $invoice->setDescription('A description without the project.');
+
+        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
+
+        $this->assertContains('invoice_recordable.error_external_description_missing_project_name', $errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsExternalTriggeredByEntryMaterialNumber(): void
+    {
+        $invoice = $this->createExternalInvoice();
+        // Clear the invoice-level material number; an entry alone makes it external.
+        $invoice->setDefaultMaterialNumber(MaterialNumberEnum::NONE);
+        $externalEntry = new InvoiceEntry();
+        $externalEntry->setEntryType(InvoiceEntryTypeEnum::MANUAL);
+        $externalEntry->setAmount(2.0);
+        $externalEntry->setMaterialNumber(MaterialNumberEnum::EXTERNAL_WITHOUT_MOMS);
+        $invoice->addInvoiceEntry($externalEntry);
+        $invoice->setDefaultReceiverAccount('SOME-OTHER-ACCOUNT');
+
+        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
+
+        $this->assertContains('invoice_recordable.error_external_receiver_account', $errors);
+    }
+
+    public function testGetInvoiceRecordableErrorsInternalInvoiceSkipsExternalChecks(): void
+    {
+        $invoice = $this->createExternalInvoice();
+        $invoice->setDefaultMaterialNumber(MaterialNumberEnum::INTERNAL);
+        // These would all fail the external checks, but must be ignored for internal invoices.
+        $invoice->setDefaultReceiverAccount('SOME-OTHER-ACCOUNT');
+        $invoice->setPeriodFrom(null);
+        $invoice->setPeriodTo(null);
+        $invoice->setDescription(null);
 
         $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
 

--- a/tests/Unit/Service/ProjectBillingServiceTest.php
+++ b/tests/Unit/Service/ProjectBillingServiceTest.php
@@ -13,6 +13,7 @@ use App\Entity\ProjectBilling;
 use App\Entity\Version;
 use App\Entity\Worklog;
 use App\Enum\ClientTypeEnum;
+use App\Enum\MaterialNumberEnum;
 use App\Exception\EconomicsException;
 use App\Exception\InvoiceAlreadyOnRecordException;
 use App\Repository\ClientRepository;
@@ -370,6 +371,38 @@ class ProjectBillingServiceTest extends TestCase
         $this->assertNotEmpty($invoiceEntries);
         $this->assertNotEmpty($invoices);
         $this->assertCount(1, $projectBilling->getInvoices());
+    }
+
+    public function testCreateProjectBillingUsesClientTypeMaterialNumber(): void
+    {
+        $project = new Project();
+        $project->setName('Test');
+        $projectBilling = $this->createProjectBillingEntity($project);
+        $this->setEntityId($projectBilling, 1);
+
+        $client = new Client();
+        $client->setName('External without moms');
+        $client->setType(ClientTypeEnum::EXTERNAL_WITHOUT_MOMS);
+        $this->setEntityId($client, 11);
+
+        $issue = $this->createIssueWithWorklog();
+        $version = new Version();
+        $version->setName('PB-ClientA');
+        $version->setProjectTrackerId('v1');
+        $issue->addVersion($version);
+
+        $this->projectBillingRepository->method('find')->willReturn($projectBilling);
+        $this->issueRepository->method('getClosedIssuesFromInterval')->willReturn([$issue]);
+        $this->clientRepository->method('findOneBy')->with(['versionName' => 'PB-ClientA'])->willReturn($client);
+        $this->clientHelper->method('getStandardPrice')->willReturn(500.0);
+
+        $this->entityManager->method('persist');
+
+        $this->service->createProjectBilling(1);
+
+        $invoice = $projectBilling->getInvoices()->first();
+        $this->assertInstanceOf(Invoice::class, $invoice);
+        $this->assertSame(MaterialNumberEnum::EXTERNAL_WITHOUT_MOMS, $invoice->getDefaultMaterialNumber());
     }
 
     public function testCreateProjectBillingCreatesProductInvoiceEntries(): void

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -358,6 +358,9 @@ invoice_recordable:
   error_no_contact: "Ingen kontakt"
   error_no_type: "Ingen type"
   error_empty_invoice_entry: "Fakturaindgangen med id: %invoiceEntryId% har et tomt antal"
+  error_external_receiver_account: "Til-kontoen skal være skiftet til ITK Dev Ekstern på eksterne fakturaer"
+  error_external_missing_period: "Der skal være sat både fra- og til-dato på eksterne fakturaer"
+  error_external_description_missing_project_name: "Beskrivelsen skal indeholde projektets navn på eksterne fakturaer"
 
 title: "Economics"
 

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -700,7 +700,9 @@ delete:
 
 client_type_enum:
   internal: "Intern"
-  external: "Ekstern"
+  external: "Ekstern (udgår)"
+  external_with_moms: "Ekstern m/moms"
+  external_without_moms: "Ekstern u/moms"
 
 users:
   title: "Brugere"


### PR DESCRIPTION
#### Link to ticket

[#7808](https://leantime.itkdev.dk/#/tickets/showTicket/7808)

#### Description

This PR sets out to increase the quality of life, and reduce rate of error when creating external invoices.

- Validate external invoices before "Bogførsel" (receiver account, from/to dates, project name in description).
- Split client type into "Ekstern m/moms" and "Ekstern u/moms" (export covers all external variants).
- Old client type "Ekstern" remains for legacy reasons (Can't migrate to new options right now, but we will probably be able to remove it later)
- Autofill invoice material number from the client type.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
