### PR TITLE
feat: remove invoice description project name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-321](https://github.com/itk-dev/economics/pull/321)
+  * Removed the invoice description project name check.
 * [PR-318](https://github.com/itk-dev/economics/pull/318)
   * Quality-of-life improvements for external invoices.
 

--- a/src/Service/BillingService.php
+++ b/src/Service/BillingService.php
@@ -165,12 +165,6 @@ class BillingService
             if (is_null($invoice->getPeriodFrom()) || is_null($invoice->getPeriodTo())) {
                 $errors[] = $this->translator->trans('invoice_recordable.error_external_missing_period');
             }
-
-            $projectName = $invoice->getProject()?->getName();
-            if (!empty($projectName)
-                && !str_contains(mb_strtolower($invoice->getDescription() ?? ''), mb_strtolower($projectName))) {
-                $errors[] = $this->translator->trans('invoice_recordable.error_external_description_missing_project_name');
-            }
         }
 
         return $errors;

--- a/tests/Unit/Service/BillingServiceTest.php
+++ b/tests/Unit/Service/BillingServiceTest.php
@@ -448,16 +448,6 @@ class BillingServiceTest extends TestCase
         $this->assertContains('invoice_recordable.error_external_missing_period', $errors);
     }
 
-    public function testGetInvoiceRecordableErrorsExternalDescriptionMissingProjectName(): void
-    {
-        $invoice = $this->createExternalInvoice();
-        $invoice->setDescription('A description without the project.');
-
-        $errors = $this->billingService->getInvoiceRecordableErrors($invoice);
-
-        $this->assertContains('invoice_recordable.error_external_description_missing_project_name', $errors);
-    }
-
     public function testGetInvoiceRecordableErrorsExternalTriggeredByEntryMaterialNumber(): void
     {
         $invoice = $this->createExternalInvoice();

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -360,7 +360,6 @@ invoice_recordable:
   error_empty_invoice_entry: "Fakturaindgangen med id: %invoiceEntryId% har et tomt antal"
   error_external_receiver_account: "Til-kontoen skal være skiftet til ITK Dev Ekstern på eksterne fakturaer"
   error_external_missing_period: "Der skal være sat både fra- og til-dato på eksterne fakturaer"
-  error_external_description_missing_project_name: "Beskrivelsen skal indeholde projektets navn på eksterne fakturaer"
 
 title: "Economics"
 


### PR DESCRIPTION
#### Link to ticket

[#7808](https://leantime.itkdev.dk/#/tickets/showTicket/7808)

#### Description

Testing of the previous feature showed, that the project name is not always the correct project name to put in the description, due to how PL's handle "sub-projects" inside projects via tags.

Removing check on project name in description for external invoices.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
