### PR TITLE
fix: stop the Leantime pagination cursor restarting the sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-326](https://github.com/itk-dev/economics/pull/326)
+  * Fixed the pagination cursor in `updateAsJob()` restarting the sync from the beginning: it took the id of the
+    last row on the page, so a null or out-of-order id rewound the cursor and the sync looped over the same rows
+    forever, starving the single worker. It now follows the highest usable id on the page, and a full page with
+    no usable id stops with an error.
 * [PR-325](https://github.com/itk-dev/economics/pull/325)
   * Fixed the Leantime sync halting silently on a single bad row: `LeantimeApiService` and the sync message
     handlers now catch `\Throwable`, and the upsert dispatch moved inside the same `try`. A skipped row logs
@@ -17,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `deleted-user-<userId>`, a missing name becomes `(no name)`, and rows with no `ticketId`/`projectId` are skipped.
   * Fixed the `/deleted` request sending its timestamp as `deletedAfter` rather than `deleted`, which made every
     delete-sync pull the entire unpaginated deletion history. Deletion entries with no id are now skipped and logged.
-  * Fixed the pagination cursor in `updateAsJob()` restarting the sync from the beginning: it took the id of the
-    last row on the page, so a null or out-of-order id rewound the cursor and the sync looped over the same rows
-    forever, starving the single worker. It now follows the highest usable id on the page, and a full page with
-    no usable id stops with an error.
 * [PR-324](https://github.com/itk-dev/economics/pull/324)
   Added game center with snake
 * [PR-303](https://github.com/itk-dev/economics/pull/303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     plugin ignores — it reads `deleted`. Every delete-sync was pulling the entire deletion
     history, on an endpoint the plugin does not paginate. Deletion entries with no id are
     now skipped and logged rather than aborting the remaining types.
+  * Fixed the pagination cursor in `updateAsJob()` restarting the sync from the beginning.
+    The cursor took the id of the last row on the page, so a null id left it null and
+    `null + 1` queued the next page at `start: 1` — the sync looped over the same rows
+    forever, starving the single worker of every other job. Out-of-order ids moved the
+    cursor backwards the same way. It now follows the highest usable id on the page, and a
+    full page with no usable id stops with an error rather than looping invisibly.
   * Added `LeantimeApiServiceTest::testUpdateWithNullValues()`, covering the nullable payload
     from data-api#18 plus two probes that a single unmappable row is logged and skipped
     rather than stopping the sync: a `TypeError` and a failure raised inside the upsert
     handler. The `/deleted` fixture gained an entry with no id.
+  * Added `tests/Unit/Service/LeantimeApiServiceTest.php` covering the pagination cursor:
+    a null trailing id, descending ids, a page with no usable id, and the partial-page
+    termination condition. The existing integration tests never reached the next-page
+    branch, since their fixtures are all partial pages.
 * [PR-324](https://github.com/itk-dev/economics/pull/324)
   Added game center with snake
 * [PR-303](https://github.com/itk-dev/economics/pull/303)

--- a/src/Service/LeantimeApiService.php
+++ b/src/Service/LeantimeApiService.php
@@ -197,12 +197,19 @@ class LeantimeApiService implements DataProviderInterface
         $fetchDate = new \DateTime();
 
         // Queue upsert.
+        $maxId = null;
+
         foreach ($data->results as $result) {
             $this->dispatchUpsertMessage($className, $result, $dataProviderId, $fetchDate, $asyncJobQueue, $dataProviderUrl, $disableModifiedAtCheck);
-            $startId = $result->id;
-        }
 
-        $startId = $startId + 1;
+            // Track the highest id rather than the last one seen: a null id left $startId null,
+            // and null + 1 is 1, so the next page restarted the sync from the beginning and
+            // re-queued itself forever. Out-of-order ids moved the cursor backwards the same way.
+            if (is_numeric($result->id ?? null)) {
+                $id = (int) $result->id;
+                $maxId = null === $maxId ? $id : max($maxId, $id);
+            }
+        }
 
         // Clear the entity manager in sync handling, to avoid memory issues.
         if (!$asyncJobQueue) {
@@ -211,8 +218,16 @@ class LeantimeApiService implements DataProviderInterface
 
         // Queue next page.
         if ($data->resultsCount === $limit) {
+            // A full page with nothing to advance on cannot be paged past. Stopping is visible in
+            // the log; continuing would re-read the same page until the queue starves.
+            if (null === $maxId || $maxId < $startId) {
+                $this->logger->error(sprintf('Stopping %s sync at start %d: no usable id on a full page, cursor cannot advance.', $className, $startId));
+
+                return;
+            }
+
             $this->messageBus->dispatch(
-                new LeantimeUpdateMessage($className, $startId, $limit, $dataProviderId, $asyncJobQueue, $modifiedAfter, $projectTrackerProjectIds, $disableModifiedAtCheck),
+                new LeantimeUpdateMessage($className, $maxId + 1, $limit, $dataProviderId, $asyncJobQueue, $modifiedAfter, $projectTrackerProjectIds, $disableModifiedAtCheck),
                 [new TransportNamesStamp($asyncJobQueue ? $this::QUEUE_ASYNC : $this::QUEUE_SYNC)],
             );
         }

--- a/tests/Unit/Service/LeantimeApiServiceTest.php
+++ b/tests/Unit/Service/LeantimeApiServiceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DataProvider;
+use App\Entity\Project;
+use App\Message\LeantimeUpdateMessage;
+use App\Repository\DataProviderRepository;
+use App\Repository\ProjectRepository;
+use App\Service\LeantimeApiService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Pagination cursor behaviour of updateAsJob().
+ *
+ * The cursor is what keeps the sync moving: updateAsJob() queues the next page as its last action,
+ * using the ids of the rows it just saw. A cursor that fails to advance re-queues the same page
+ * forever and the single worker never drains.
+ */
+class LeantimeApiServiceTest extends TestCase
+{
+    private const LIMIT = 100;
+
+    /** @var list<object> */
+    private array $dispatched = [];
+
+    private LoggerInterface $logger;
+
+    /** @var list<string> */
+    private array $loggedErrors = [];
+
+    public function testNextPageStartsAfterHighestId(): void
+    {
+        $service = $this->createService($this->page(range(1, self::LIMIT)));
+
+        $service->updateAsJob(Project::class, 0, self::LIMIT, 1);
+
+        $this->assertSame(self::LIMIT + 1, $this->nextPageMessage()->start);
+    }
+
+    /**
+     * A null id on the last row used to leave $startId null, and null + 1 is 1 — the next page
+     * restarted the sync from the beginning and re-queued itself forever.
+     */
+    public function testNullIdOnLastRowDoesNotResetCursor(): void
+    {
+        $ids = range(1, self::LIMIT);
+        $ids[self::LIMIT - 1] = null;
+
+        $service = $this->createService($this->page($ids));
+
+        $service->updateAsJob(Project::class, 0, self::LIMIT, 1);
+
+        $next = $this->nextPageMessage();
+        $this->assertNotSame(1, $next->start, 'A null trailing id must not restart the sync from the beginning.');
+        $this->assertSame(self::LIMIT, $next->start, 'The cursor should follow the highest usable id on the page.');
+    }
+
+    public function testDescendingIdsDoNotMoveCursorBackwards(): void
+    {
+        $service = $this->createService($this->page(range(self::LIMIT, 1)));
+
+        $service->updateAsJob(Project::class, 0, self::LIMIT, 1);
+
+        $this->assertSame(self::LIMIT + 1, $this->nextPageMessage()->start);
+    }
+
+    /**
+     * With no usable id anywhere on a full page the cursor genuinely cannot advance. Stopping
+     * loudly beats looping: an invisible infinite loop starves every other sync of the one worker.
+     */
+    public function testPageWithNoUsableIdStopsAndLogs(): void
+    {
+        $service = $this->createService($this->page(array_fill(0, self::LIMIT, null)));
+
+        $service->updateAsJob(Project::class, 40, self::LIMIT, 1);
+
+        $this->assertNull($this->findNextPageMessage(), 'No next page may be queued when the cursor cannot advance.');
+        $this->assertCount(1, $this->loggedErrors);
+        $this->assertStringContainsString(Project::class, $this->loggedErrors[0]);
+        $this->assertStringContainsString('40', $this->loggedErrors[0]);
+    }
+
+    public function testPartialPageQueuesNoNextPage(): void
+    {
+        $service = $this->createService($this->page(range(1, 10)));
+
+        $service->updateAsJob(Project::class, 0, self::LIMIT, 1);
+
+        $this->assertNull($this->findNextPageMessage());
+    }
+
+    /**
+     * A page of project rows with the given ids. Only the cursor matters here, so every other
+     * field is fixed and valid.
+     *
+     * @param array<int, int|null> $ids
+     */
+    private function page(array $ids): object
+    {
+        $results = array_map(static fn ($id) => (object) [
+            'id' => $id,
+            'name' => 'Project '.($id ?? 'null'),
+            'modified' => '2026-07-30 12:00:00',
+        ], array_values($ids));
+
+        return (object) [
+            'results' => $results,
+            'resultsCount' => count($results),
+        ];
+    }
+
+    private function createService(object $page): LeantimeApiService
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getContent')->willReturn(json_encode($page));
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $this->dispatched = [];
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            function (object $message, array $stamps = []): Envelope {
+                $this->dispatched[] = $message;
+
+                return new Envelope($message, $stamps);
+            }
+        );
+
+        $dataProvider = new DataProvider();
+        $dataProvider->setName('Test provider');
+        $dataProvider->setEnabled(true);
+        $dataProvider->setClass(LeantimeApiService::class);
+        $dataProvider->setUrl('http://localhost/');
+        $dataProvider->setSecret('Not so secret');
+
+        $dataProviderRepository = $this->createMock(DataProviderRepository::class);
+        $dataProviderRepository->method('find')->willReturn($dataProvider);
+
+        $this->loggedErrors = [];
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->logger->method('error')->willReturnCallback(
+            function (string $message): void {
+                $this->loggedErrors[] = $message;
+            }
+        );
+
+        return new LeantimeApiService(
+            $httpClient,
+            $messageBus,
+            $dataProviderRepository,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(ProjectRepository::class),
+            $this->logger,
+        );
+    }
+
+    private function nextPageMessage(): LeantimeUpdateMessage
+    {
+        $message = $this->findNextPageMessage();
+        $this->assertNotNull($message, 'Expected a next-page message to be queued.');
+
+        return $message;
+    }
+
+    private function findNextPageMessage(): ?LeantimeUpdateMessage
+    {
+        foreach ($this->dispatched as $message) {
+            if ($message instanceof LeantimeUpdateMessage) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/8000

#### Description

Stacks on https://github.com/itk-dev/economics/pull/325

updateAsJob() took the cursor from the id of the last row on the page. A null id left $startId null, and null + 1 is 1, so the next page was queued at start: 1 — the sync looped over the same rows forever. With one worker and a chain that re-queues itself, that starves every other sync indefinitely. Out-of-order ids moved the cursor backwards the same way.

The cursor now follows the highest usable id on the page, ignoring null and non-numeric ones. A full page with no usable id cannot be paged past at all, so it stops and logs rather than looping invisibly.

The id was read outside the try in dispatchUpsertMessage(), so the \Throwable handling added in ebb146b9 never covered it. deleteAsJob() got the equivalent null-id guard in b7c001a4; updateAsJob() did not.

The existing integration tests never reached the next-page branch — their fixtures are all partial pages — hence the new unit test for the cursor.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.