### PR TITLE
7720-extra: Guard recorded invoice worklog lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-329](https://github.com/itk-dev/economics/pull/329)
+  Blocked worklog selection on recorded invoices.
 * [PR-328](https://github.com/itk-dev/economics/pull/328)
   Added selected and total hours to the worklog selection list.
 * [PR-324](https://github.com/itk-dev/economics/pull/324)

--- a/src/Controller/InvoiceEntryWorklogController.php
+++ b/src/Controller/InvoiceEntryWorklogController.php
@@ -41,6 +41,10 @@ class InvoiceEntryWorklogController extends AbstractController
             throw new EconomicsException($this->translator->trans('exception.invoice_entry_not_worklog_type'), 400);
         }
 
+        if ($invoice->isRecorded()) {
+            return $this->redirectToRoute('app_invoice_entry_worklogs_show', ['invoice' => $invoice->getId(), 'invoiceEntry' => $invoiceEntry->getId()], Response::HTTP_SEE_OTHER);
+        }
+
         $project = $invoice->getProject();
 
         if (is_null($project)) {
@@ -123,6 +127,10 @@ class InvoiceEntryWorklogController extends AbstractController
     #[Route('/{invoiceEntry}/select_worklogs', name: 'app_invoice_entry_select_worklogs', methods: ['POST'])]
     public function selectWorklogs(Request $request, InvoiceEntry $invoiceEntry, WorklogRepository $worklogRepository, BillingService $billingService): Response
     {
+        if ($invoiceEntry->getInvoice()?->isRecorded()) {
+            return new JsonResponse(['message' => $this->translator->trans('worklog.error_invoice_recorded')], 400);
+        }
+
         $worklogSelections = $request->toArray();
 
         foreach ($worklogSelections as $worklogSelection) {

--- a/tests/Integration/Controller/InvoiceFullFlowTest.php
+++ b/tests/Integration/Controller/InvoiceFullFlowTest.php
@@ -290,6 +290,51 @@ class InvoiceFullFlowTest extends AbstractControllerTestCase
         // 10. HTML export preview still works after record.
         $client->request('GET', '/admin/invoices/'.$invoiceId.'/show-export');
         $this->assertResponseIsSuccessful();
+
+        // 11. The worklog selection is closed once the invoice is recorded.
+        $client->request('GET', '/admin/invoices/'.$invoiceId.'/entries/'.$worklogEntryId.'/worklogs');
+        $this->assertResponseRedirects('/admin/invoices/'.$invoiceId.'/entries/'.$worklogEntryId.'/worklogs-show');
+
+        $client->request('GET', '/admin/invoices/'.$invoiceId.'/entries/'.$worklogEntryId.'/worklogs-show');
+        $this->assertResponseIsSuccessful();
+
+        $worklogRepository = static::getContainer()->get(WorklogRepository::class);
+        $this->assertInstanceOf(WorklogRepository::class, $worklogRepository);
+
+        $unassigned = null;
+        foreach ($worklogRepository->findBy(['project' => $project, 'isBilled' => false], ['id' => 'ASC'], 50) as $wl) {
+            if (null === $wl->getInvoiceEntry()) {
+                $unassigned = $wl;
+                break;
+            }
+        }
+        $this->assertInstanceOf(Worklog::class, $unassigned, 'Expected a spare unassigned worklog in fixtures.');
+        $unassignedId = $unassigned->getId();
+
+        $worklogEntry = $this->reloadInvoiceEntry($worklogEntryId);
+        $this->assertInstanceOf(InvoiceEntry::class, $worklogEntry);
+        $amountBefore = $worklogEntry->getAmount();
+
+        $client->request(
+            'POST',
+            '/admin/invoices/'.$invoiceId.'/entries/'.$worklogEntryId.'/select_worklogs',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            (string) json_encode([['id' => $unassignedId, 'checked' => true]]),
+        );
+        $this->assertResponseStatusCodeSame(400);
+
+        $worklogEntry = $this->reloadInvoiceEntry($worklogEntryId);
+        $this->assertInstanceOf(InvoiceEntry::class, $worklogEntry);
+        $this->assertEqualsWithDelta($amountBefore, $worklogEntry->getAmount(), 0.0001);
+
+        $worklogRepository = static::getContainer()->get(WorklogRepository::class);
+        $this->assertInstanceOf(WorklogRepository::class, $worklogRepository);
+        $this->assertNull(
+            $worklogRepository->find($unassignedId)?->getInvoiceEntry(),
+            'Expected the worklog to stay unassigned when the invoice is recorded.'
+        );
     }
 
     /**

--- a/translations/messages.da.yaml
+++ b/translations/messages.da.yaml
@@ -342,6 +342,7 @@ worklog:
   action_save: "Gem valgte worklogs"
   error_already_billed: "Fejl: Indeholder worklog der allerede er faktureret. Prøv at genindlæse siden..."
   error_added_to_other_invoice_entry: "Fejl: Indeholder worklog der er bundet til anden fakturaindgang. Prøv at genindlæse siden..."
+  error_invoice_recorded: "Fejl: Fakturaen er bogført og fakturalinjens worklogs kan derfor ikke ændres."
   only_available_false: "Nej. Vis alle."
   only_available_true: "Ja"
   only_available: 'Kun "frie" worklogs'


### PR DESCRIPTION
#### Link to ticket

[#7720](https://leantime.itkdev.dk/#/tickets/showTicket/7220)

#### Description

Add guard to prevent editing invoice worklog lines on an invoice which is "Recorded". 

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
